### PR TITLE
Spelling & grammar fixes. Alligned header comments.

### DIFF
--- a/config/config.dtd
+++ b/config/config.dtd
@@ -12,10 +12,10 @@
 			<!ATTLIST bot name CDATA #REQUIRED>
 
 
-			<!ELEMENT appearance (description, (texture | color |clone))>
+			<!ELEMENT appearance (description, (texture | color | clone))>
 				<!ATTLIST appearance type CDATA #REQUIRED>
 				<!ELEMENT texture (#PCDATA)>
 				<!ELEMENT color (#PCDATA)>
-					<!ATTLIST color type (ambient| diffuse | specular| emmissive) "ambient">
+					<!ATTLIST color type (ambient | diffuse | specular | emmissive) "ambient">
 				<!ELEMENT clone (#PCDATA)>
 

--- a/ctSim/ComConnection.java
+++ b/ctSim/ComConnection.java
@@ -39,18 +39,17 @@ import ctSim.util.SaferThread;
  * Bots). Der Treiber, den wir mit unserem USB-2-Bot-Adapter verwenden, emuliert
  * einen seriellen Anschluss. Dieser kann dann von dieser Klasse angesprochen
  * werden.
- * </p>
- * <p>
+ * 
  * Die <a href="http://fazecast.github.io/jSerialComm/">jSerialComm-Dokumentation</a>
  * beschreibt die API, die in dieser Klasse verwendet wird ({@com.fazecast.jSerialComm.*}).
  * </p>
  *
  * @author Maximilian Odendahl (maximilian.odendahl@rwth-aachen.de)
- * @author Hendrik Krauß &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * @author Hendrik Krauß (hkr@heise.de)
  * @author Timo Sandmann
  */
 public class ComConnection extends Connection {
-	/** Input verfuegbar? */
+	/** Input verfügbar? */
 	protected boolean inputAvailable = false;
 	/** Mutex */
 	protected final Object inputAvailMutex = new Object();
@@ -97,9 +96,7 @@ public class ComConnection extends Connection {
 		});
 	}
 
-	/**
-	 * Registriert einen Listener
-	 */
+	/** Registriert einen Listener */
 	private void registerEventListener() {
 		class OurEventListener implements SerialPortDataListener {
 			@Override
@@ -109,7 +106,7 @@ public class ComConnection extends Connection {
 			@Override
 			public void serialEvent(SerialPortEvent evt) {
 				if (evt.getEventType() == SerialPort.LISTENING_EVENT_DATA_AVAILABLE) {
-					// Es gibt was zu lesen
+					// Es gibt etwas zu lesen
 					synchronized (inputAvailMutex) {
 						inputAvailable = true;
 						inputAvailMutex.notify();
@@ -122,7 +119,8 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Wartet, bis neue Daten eingetroffen sind
+	 * Wartet, bis neue Daten eingetroffen sind.
+	 * 
 	 * @throws InterruptedException
 	 */
 	public void blockUntilDataAvailable() throws InterruptedException {
@@ -135,7 +133,8 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Liest Daten aus einem Inputstream
+	 * Liest Daten aus einem Inputstream.
+	 * 
 	 * @throws IOException
 	 */
 	@Override
@@ -146,7 +145,7 @@ public class ComConnection extends Connection {
 
 	/**
 	 * Tut nichts: ComConnection ist ein Singleton und soll nie geschlossen
-	 * werden. Wir verhindern durch den Override auch, dass die Vaterklasse was
+	 * werden. Wir verhindern durch den Override auch, dass die Vaterklasse etwas
 	 * schließt.
 	 */
 	@Override
@@ -155,7 +154,8 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Gibt den Namen des Ports unserer Connection zurück
+	 * Gibt den Namen des Ports unserer Connection zurück.
+	 * 
 	 * @return	Name 
 	 */
 	@Override
@@ -164,7 +164,8 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Gibt den Kurznamen unserer Connection zurück
+	 * Gibt den Kurznamen unserer Connection zurück.
+	 * 
 	 * @return	"USB"
 	 */
 	@Override
@@ -183,8 +184,10 @@ public class ComConnection extends Connection {
 	private static BotReceiver botReceiver = null; 
 	
 	/**
-	 * Erzeugt einen Bot
-	 * Überschreibt die entsprechende Methode von Connection, weil hier ein paar Sondersachen dazukommen
+	 * Erzeugt einen Bot.
+	 * Überschreibt die entsprechende Methode von Connection,
+	 * weil hier ein paar Sondersachen dazukommen
+	 * 
 	 * @param c Kommando
 	 * @return Bot
 	 * @throws ProtocolException
@@ -210,7 +213,8 @@ public class ComConnection extends Connection {
 	}	
 	
 	/**
-	 * Startet das Lauschen für neue Bots
+	 * Startet das Lauschen für neue Bots.
+	 * 
 	 * @param receiver	BotReceiver für neuen Bot
 	 */
 	public static void startListening(final BotReceiver receiver) {
@@ -231,6 +235,7 @@ public class ComConnection extends Connection {
 
 	/**
 	 * Neuer Thread
+	 * 
 	 * @param receiver Bot-Receiver
 	 */
 	private static void spawnThread(BotReceiver receiver) {
@@ -247,14 +252,15 @@ public class ComConnection extends Connection {
 		private static final long serialVersionUID = 4896454703538812700L;
 
 		/**
-		 * Erzeugt eine neue Exception
+		 * Erzeugt eine neue Exception.
 		 */
 		public CouldntOpenTheDamnThingException() {
 			super();
 		}
 
 		/**
-		 * Erzeugt eine neue Exception
+		 * Erzeugt eine neue Exception.
+		 * 
 		 * @param message	Text der Exception
 		 * @param cause		
 		 */
@@ -263,7 +269,8 @@ public class ComConnection extends Connection {
 		}
 
 		/**
-		 * Erzeugt eine neue Exception
+		 * Erzeugt eine neue Exception.
+		 * 
 		 * @param message	Text der Exception
 		 */
 		public CouldntOpenTheDamnThingException(String message) {
@@ -271,7 +278,8 @@ public class ComConnection extends Connection {
 		}
 
 		/**
-		 * Erzeugt eine neue Exception
+		 * Erzeugt eine neue Exception.
+		 * 
 		 * @param cause
 		 */
 		public CouldntOpenTheDamnThingException(Throwable cause) {
@@ -279,15 +287,14 @@ public class ComConnection extends Connection {
 		}
 	}
 	
-	/**
-	 * Thread, der die COM-Connection überwacht
-	 */
+	/** Thread, der die COM-Connection überwacht. */
 	static class ComListenerThread extends SaferThread {
 		/** Bot-Receiver */
 		private final BotReceiver botReceiver;
 		
 		/**
 		 * Erzeugt einen Thread, der auf COM-Connections lauscht
+		 * 
 		 * @param receiver	BotReceiver für den neuen Bot
 		 */
 		public ComListenerThread(BotReceiver receiver) {
@@ -297,6 +304,7 @@ public class ComConnection extends Connection {
 		
 		/**
 		 * work-Methode des Threads
+		 * 
 		 * @throws InterruptedException
 		 */
 		@Override
@@ -315,6 +323,7 @@ public class ComConnection extends Connection {
 //				}
 //			});
 //			botReceiver.onBotAppeared(b);
+
 			die();
 		}
 	}

--- a/ctSim/ComConnection.java
+++ b/ctSim/ComConnection.java
@@ -288,13 +288,13 @@ public class ComConnection extends Connection {
 		}
 	}
 	
-	/** Thread, der die COM-Connection überwacht. */
+	/** Thread, der die COM-Connection überwacht */
 	static class ComListenerThread extends SaferThread {
 		/** Bot-Receiver */
 		private final BotReceiver botReceiver;
 		
 		/**
-		 * Erzeugt einen Thread, der auf COM-Connections lauscht.
+		 * Erzeugt einen Thread, der auf COM-Connections lauscht
 		 * 
 		 * @param receiver	BotReceiver für den neuen Bot
 		 */

--- a/ctSim/ComConnection.java
+++ b/ctSim/ComConnection.java
@@ -157,7 +157,7 @@ public class ComConnection extends Connection {
 	/**
 	 * Gibt den Namen des Ports unserer Connection zurück
 	 * 
-	 * @return	Name 
+	 * @return Name 
 	 */
 	@Override
 	public String getName() {
@@ -167,7 +167,7 @@ public class ComConnection extends Connection {
 	/**
 	 * Gibt den Kurznamen unserer Connection zurück
 	 * 
-	 * @return	"USB"
+	 * @return "USB"
 	 */
 	@Override
 	public String getShortName() { 
@@ -189,7 +189,7 @@ public class ComConnection extends Connection {
 	 * Überschreibt die entsprechende Methode von Connection,
 	 * weil hier ein paar Sondersachen dazukommen
 	 * 
-	 * @param c Kommando
+	 * @param c	Kommando
 	 * @return Bot
 	 * @throws ProtocolException
 	 */
@@ -237,7 +237,7 @@ public class ComConnection extends Connection {
 	/**
 	 * Neuer Thread
 	 * 
-	 * @param receiver Bot-Receiver
+	 * @param receiver	Bot-Receiver
 	 */
 	private static void spawnThread(BotReceiver receiver) {
 		new ComListenerThread(receiver).start();

--- a/ctSim/ComConnection.java
+++ b/ctSim/ComConnection.java
@@ -39,7 +39,8 @@ import ctSim.util.SaferThread;
  * Bots). Der Treiber, den wir mit unserem USB-2-Bot-Adapter verwenden, emuliert
  * einen seriellen Anschluss. Dieser kann dann von dieser Klasse angesprochen
  * werden.
- * 
+ * </p>
+ * <p>
  * Die <a href="http://fazecast.github.io/jSerialComm/">jSerialComm-Dokumentation</a>
  * beschreibt die API, die in dieser Klasse verwendet wird ({@com.fazecast.jSerialComm.*}).
  * </p>
@@ -59,7 +60,7 @@ public class ComConnection extends Connection {
 	/**
 	 * Baut eine COM-Verbindung auf (d.h. i.d.R. zum USB-2-Bot-Adapter).
 	 * Verwendet die in der Konfigdatei angegebenen Werte.
-	 *
+	 * 
 	 * @throws CouldntOpenTheDamnThingException
 	 */
 	private ComConnection() throws CouldntOpenTheDamnThingException {
@@ -119,7 +120,7 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Wartet, bis neue Daten eingetroffen sind.
+	 * Wartet, bis neue Daten eingetroffen sind
 	 * 
 	 * @throws InterruptedException
 	 */
@@ -133,7 +134,7 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Liest Daten aus einem Inputstream.
+	 * Liest Daten aus einem Inputstream
 	 * 
 	 * @throws IOException
 	 */
@@ -154,7 +155,7 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Gibt den Namen des Ports unserer Connection zurück.
+	 * Gibt den Namen des Ports unserer Connection zurück
 	 * 
 	 * @return	Name 
 	 */
@@ -164,7 +165,7 @@ public class ComConnection extends Connection {
 	}
 
 	/**
-	 * Gibt den Kurznamen unserer Connection zurück.
+	 * Gibt den Kurznamen unserer Connection zurück
 	 * 
 	 * @return	"USB"
 	 */
@@ -213,7 +214,7 @@ public class ComConnection extends Connection {
 	}	
 	
 	/**
-	 * Startet das Lauschen für neue Bots.
+	 * Startet das Lauschen für neue Bots
 	 * 
 	 * @param receiver	BotReceiver für neuen Bot
 	 */
@@ -252,14 +253,14 @@ public class ComConnection extends Connection {
 		private static final long serialVersionUID = 4896454703538812700L;
 
 		/**
-		 * Erzeugt eine neue Exception.
+		 * Erzeugt eine neue Exception
 		 */
 		public CouldntOpenTheDamnThingException() {
 			super();
 		}
 
 		/**
-		 * Erzeugt eine neue Exception.
+		 * Erzeugt eine neue Exception
 		 * 
 		 * @param message	Text der Exception
 		 * @param cause		
@@ -269,7 +270,7 @@ public class ComConnection extends Connection {
 		}
 
 		/**
-		 * Erzeugt eine neue Exception.
+		 * Erzeugt eine neue Exception
 		 * 
 		 * @param message	Text der Exception
 		 */
@@ -278,7 +279,7 @@ public class ComConnection extends Connection {
 		}
 
 		/**
-		 * Erzeugt eine neue Exception.
+		 * Erzeugt eine neue Exception
 		 * 
 		 * @param cause
 		 */
@@ -293,7 +294,7 @@ public class ComConnection extends Connection {
 		private final BotReceiver botReceiver;
 		
 		/**
-		 * Erzeugt einen Thread, der auf COM-Connections lauscht
+		 * Erzeugt einen Thread, der auf COM-Connections lauscht.
 		 * 
 		 * @param receiver	BotReceiver für den neuen Bot
 		 */

--- a/ctSim/ConfigManager.java
+++ b/ctSim/ConfigManager.java
@@ -41,7 +41,7 @@ public class ConfigManager {
 	}
 
 	/**
-	 * Wandelt einen Pfad mit Bot-Binary von Linux zu Windows.
+	 * Wandelt einen Pfad mit Bot-Binary von Linux zu Windows
 	 * 
 	 * @param in der Originalstring
 	 * @return der "Windows-String"
@@ -55,7 +55,7 @@ public class ConfigManager {
 	}
 
 	/**
-	 * Passt einen Pfad an das aktuelle OS an.
+	 * Passt einen Pfad an das aktuelle OS an
 	 * 
 	 * @param in der Originalstring
 	 * @return der angepasste String

--- a/ctSim/ConfigManager.java
+++ b/ctSim/ConfigManager.java
@@ -29,7 +29,7 @@ public class ConfigManager {
 	/**
 	 * Wandelt einen Pfad mit Bot-Binary von Windows zu Linux
 	 * 
-	 * @param in der Originalstring
+	 * @param in	der Originalstring
 	 * @return der "Linux-String"
 	 */
 	private static String botPathWin2Lin(String in){
@@ -43,7 +43,7 @@ public class ConfigManager {
 	/**
 	 * Wandelt einen Pfad mit Bot-Binary von Linux zu Windows
 	 * 
-	 * @param in der Originalstring
+	 * @param in	der Originalstring
 	 * @return der "Windows-String"
 	 */
 	private static String botPathLin2Win(String in){
@@ -57,7 +57,7 @@ public class ConfigManager {
 	/**
 	 * Passt einen Pfad an das aktuelle OS an
 	 * 
-	 * @param in der Originalstring
+	 * @param in	der Originalstring
 	 * @return der angepasste String
 	 */
 	public static String path2Os(String in){

--- a/ctSim/ConfigManager.java
+++ b/ctSim/ConfigManager.java
@@ -21,15 +21,14 @@ package ctSim;
 
 import ctSim.util.FmtLogger;
 
-/**
- * OS-spezifische Anpassungen für das Einlesen der Config
- */
+/** OS-spezifische Anpassungen für das Einlesen der Config */
 public class ConfigManager {
 	/** Logger */
 	static FmtLogger lg = FmtLogger.getLogger("ctSim.ConfigManager");
 
 	/**
-	 * Wandelt einen Pfad mit Bot-Binary von Windows zu Linux
+	 * Wandelt einen Pfad mit Bot-Binary von Windows zu Linux.
+	 * 
 	 * @param in der Originalstring
 	 * @return der "Linux-String"
 	 */
@@ -42,7 +41,8 @@ public class ConfigManager {
 	}
 
 	/**
-	 * Wandelt einen Pfad mit Bot-Binary von Linux zu Windows
+	 * Wandelt einen Pfad mit Bot-Binary von Linux zu Windows.
+	 * 
 	 * @param in der Originalstring
 	 * @return der "Windows-String"
 	 */
@@ -55,7 +55,8 @@ public class ConfigManager {
 	}
 
 	/**
-	 * Passt einen Pfad an das aktuelle OS an
+	 * Passt einen Pfad an das aktuelle OS an.
+	 * 
 	 * @param in der Originalstring
 	 * @return der angepasste String
 	 */

--- a/ctSim/ConfigManager.java
+++ b/ctSim/ConfigManager.java
@@ -27,7 +27,7 @@ public class ConfigManager {
 	static FmtLogger lg = FmtLogger.getLogger("ctSim.ConfigManager");
 
 	/**
-	 * Wandelt einen Pfad mit Bot-Binary von Windows zu Linux.
+	 * Wandelt einen Pfad mit Bot-Binary von Windows zu Linux
 	 * 
 	 * @param in der Originalstring
 	 * @return der "Linux-String"

--- a/ctSim/Connection.java
+++ b/ctSim/Connection.java
@@ -104,7 +104,7 @@ public abstract class Connection {
 	/**
 	 * Liefert den Cmd-Stream
 	 * 
-	 * @return	der CommandOutputStream
+	 * @return der CommandOutputStream
 	 */
 	public synchronized CommandOutputStream getCmdOutStream() {
 		assert cmdOutStream != null;
@@ -124,7 +124,7 @@ public abstract class Connection {
 	/** 
 	 * Muss während der Konstruktion aufgerufen werden...
 	 * 
-	 * @param is InputStream
+	 * @param is	InputStream
 	 */
 	protected void setInputStream(InputStream is) {
 		input = new DataInputStream(new BufferedInputStream(is));
@@ -133,7 +133,7 @@ public abstract class Connection {
 	/**
 	 * Muss während der Konstruktion aufgerufen werden...
 	 * 
-	 * @param os OutputStream
+	 * @param os	OutputStream
 	 */
 	protected void setOutputStream(OutputStream os) {
 		output = new DataOutputStream(os);
@@ -143,14 +143,14 @@ public abstract class Connection {
 	/**
 	 * Gibt den Kurznamen der Connection zurück
 	 * 
-	 * @return	Name
+	 * @return Name
 	 */
 	public abstract String getShortName();
 
 	/**
 	 * Gibt den Namen der Connection zurück
 	 * 
-	 * @return	Name
+	 * @return Name
 	 */
 	public abstract String getName();
 	
@@ -158,7 +158,7 @@ public abstract class Connection {
 	 * Blockiert, bis Handshake erfolgreich oder IOException
 	 * Abbruch nach 100 Versuchen
 	 * 
-	 * @param receiver Bot-Receiver
+	 * @param receiver	Bot-Receiver
 	 */
 	protected void doHandshake(BotReceiver receiver) {
 		for (int i = 0; i < 1000; i++) {
@@ -195,7 +195,7 @@ public abstract class Connection {
 	/**
 	 * Erzeugt einen Bot
 	 * 
-	 * @param c Kommando
+	 * @param c	Kommando
 	 * @return Bot
 	 * @throws ProtocolException
 	 */

--- a/ctSim/Connection.java
+++ b/ctSim/Connection.java
@@ -79,7 +79,7 @@ public abstract class Connection {
 	private CommandOutputStream cmdOutStream = null;
 
 	/**
-	 * Beendet die laufende Verbindung.
+	 * Beendet die laufende Verbindung
 	 *
 	 * @throws IOException
 	 */
@@ -91,7 +91,7 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Überträgt ein Kommando.
+	 * Überträgt ein Kommando
 	 * 
 	 * @param c	das Kommando
 	 * @throws IOException
@@ -102,7 +102,7 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Liefert den Cmd-Stream.
+	 * Liefert den Cmd-Stream
 	 * 
 	 * @return	der CommandOutputStream
 	 */
@@ -112,7 +112,7 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Liest Daten aus dem InputStream.
+	 * Liest Daten aus dem InputStream
 	 * 
 	 * @param b	Daten
 	 * @throws IOException
@@ -122,7 +122,7 @@ public abstract class Connection {
 	}
 
 	/** 
-	 * Muss während Konstruktion aufgerufen werden.
+	 * Muss während der Konstruktion aufgerufen werden...
 	 * 
 	 * @param is InputStream
 	 */
@@ -131,7 +131,7 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Muss während Konstruktion aufgerufen werden.
+	 * Muss während der Konstruktion aufgerufen werden...
 	 * 
 	 * @param os OutputStream
 	 */
@@ -141,14 +141,14 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Gibt den Kurznamen der Connection zurück.
+	 * Gibt den Kurznamen der Connection zurück
 	 * 
 	 * @return	Name
 	 */
 	public abstract String getShortName();
 
 	/**
-	 * Gibt den Namen der Connection zurück.
+	 * Gibt den Namen der Connection zurück
 	 * 
 	 * @return	Name
 	 */
@@ -156,7 +156,7 @@ public abstract class Connection {
 	
 	/**
 	 * Blockiert, bis Handshake erfolgreich oder IOException
-	 * Abbruch nach 100 Versuchen.
+	 * Abbruch nach 100 Versuchen
 	 * 
 	 * @param receiver Bot-Receiver
 	 */
@@ -193,7 +193,7 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Erzeugt einen Bot.
+	 * Erzeugt einen Bot
 	 * 
 	 * @param c Kommando
 	 * @return Bot

--- a/ctSim/Connection.java
+++ b/ctSim/Connection.java
@@ -40,7 +40,7 @@ import ctSim.util.FmtLogger;
  * Repräsentiert eine Verbindung
  *
  * @author bbe (bbe@heise.de)
- * @author Hendrik Krauß &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * @author Hendrik Krauß (hkr@heise.de)
  */
 public abstract class Connection {	
 	/** Logger */
@@ -70,7 +70,7 @@ public abstract class Connection {
 	/**
 	 * Hat keinen BufferedOutputStream, denn auf dem muss man (offenbar) immer
 	 * flush() aufrufen. Wir wissen jedoch nicht, wann die Leute, die uns
-	 * verwenden, flushen wollen &amp;ndash; daher müssen die das machen
+	 * verwenden, flushen wollen - daher müssen die das machen
 	 * mit dem BufferedOutputStream.
 	 */
 	private DataOutputStream output = null;
@@ -79,7 +79,7 @@ public abstract class Connection {
 	private CommandOutputStream cmdOutStream = null;
 
 	/**
-	 * Beendet die laufende Verbindung
+	 * Beendet die laufende Verbindung.
 	 *
 	 * @throws IOException
 	 */
@@ -91,7 +91,8 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Überträgt ein Kommando
+	 * Überträgt ein Kommando.
+	 * 
 	 * @param c	das Kommando
 	 * @throws IOException
 	 */
@@ -101,7 +102,8 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Liefert den Cmd-Stream
+	 * Liefert den Cmd-Stream.
+	 * 
 	 * @return	der CommandOutputStream
 	 */
 	public synchronized CommandOutputStream getCmdOutStream() {
@@ -110,7 +112,8 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Liest Daten aus dem InputStream
+	 * Liest Daten aus dem InputStream.
+	 * 
 	 * @param b	Daten
 	 * @throws IOException
 	 */
@@ -119,7 +122,8 @@ public abstract class Connection {
 	}
 
 	/** 
-	 * Muss während Konstruktion aufgerufen werden
+	 * Muss während Konstruktion aufgerufen werden.
+	 * 
 	 * @param is InputStream
 	 */
 	protected void setInputStream(InputStream is) {
@@ -127,7 +131,8 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Muss während Konstruktion aufgerufen werden
+	 * Muss während Konstruktion aufgerufen werden.
+	 * 
 	 * @param os OutputStream
 	 */
 	protected void setOutputStream(OutputStream os) {
@@ -136,20 +141,23 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Gibt den Kurznamen der Connection zurück
+	 * Gibt den Kurznamen der Connection zurück.
+	 * 
 	 * @return	Name
 	 */
 	public abstract String getShortName();
 
 	/**
-	 * Gibt den Namen der Connection zurück
+	 * Gibt den Namen der Connection zurück.
+	 * 
 	 * @return	Name
 	 */
 	public abstract String getName();
 	
 	/**
 	 * Blockiert, bis Handshake erfolgreich oder IOException
-	 * Abbruch nach 100 Versuchen 
+	 * Abbruch nach 100 Versuchen.
+	 * 
 	 * @param receiver Bot-Receiver
 	 */
 	protected void doHandshake(BotReceiver receiver) {
@@ -185,7 +193,8 @@ public abstract class Connection {
 	}
 
 	/**
-	 * Erzeugt einen Bot
+	 * Erzeugt einen Bot.
+	 * 
 	 * @param c Kommando
 	 * @return Bot
 	 * @throws ProtocolException

--- a/ctSim/EchoTest.java
+++ b/ctSim/EchoTest.java
@@ -41,7 +41,7 @@ public class EchoTest {
 	
 	public void send(Connection connection) throws IOException{
 		Command command = new Command();
-		lastTransmittedSimulTime+=1;//(int)world.getSimulTime();
+		lastTransmittedSimulTime+=1; //(int)world.getSimulTime();
 		command.setCommand(Command.CMD_DONE);
 		command.setDataL(lastTransmittedSimulTime);
 		command.setDataR(0);
@@ -79,13 +79,14 @@ public class EchoTest {
 	
 	/**
 	 * main
+	 * 
 	 * @param args
 	 */
 	public static void main(String[] args) {
 		try{
 			EchoTest et = new EchoTest();
 			
-		//	long sendTime;
+//			long sendTime;
 			
 			ServerSocket server = new ServerSocket(10001);
 			TcpConnection tcp = new TcpConnection();
@@ -95,7 +96,7 @@ public class EchoTest {
 	
 			while(1==1){
 				et.send(tcp);
-			//	sendTime=System.nanoTime()/1000;
+//				sendTime=System.nanoTime()/1000;
 				et.receiveCommands(tcp);
 			}
 			

--- a/ctSim/Init.java
+++ b/ctSim/Init.java
@@ -23,15 +23,15 @@ import javax.swing.UIManager;
 
 import ctSim.util.FmtLogger;
 
-/**
- * Initialisierungen für ct-Sim 
+/** 
+ * Initialisierungen für ct-Sim
  */
 public class Init {
 	/** Logger */
 	static final FmtLogger lg = FmtLogger.getLogger("ctSim.controller.Init");
 	
 	/**
-	 * Setzt das Design auf Java-System oder Metal für Linux
+	 * Setzt das Design auf Java-System oder Metal für Linux.
 	 */
 	public static void setLookAndFeel() {
 		// Ubuntu 6.10 + Gnome: Stelle fest, dass c't-Sim absolut bekackt 
@@ -50,9 +50,7 @@ public class Init {
 		}
 	}
 	
-	/**
-	 * Metal-Design einstellen
-	 */
+	/** Metal-Design einstellen. */
 	private static void useMetalLookAndFeel() {
 		try {
 			UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");

--- a/ctSim/Init.java
+++ b/ctSim/Init.java
@@ -23,7 +23,7 @@ import javax.swing.UIManager;
 
 import ctSim.util.FmtLogger;
 
-/** 
+/**
  * Initialisierungen für ct-Sim
  */
 public class Init {
@@ -31,7 +31,7 @@ public class Init {
 	static final FmtLogger lg = FmtLogger.getLogger("ctSim.controller.Init");
 	
 	/**
-	 * Setzt das Design auf Java-System oder Metal für Linux.
+	 * Setzt das Design auf Java-System oder Metal für Linux
 	 */
 	public static void setLookAndFeel() {
 		// Ubuntu 6.10 + Gnome: Stelle fest, dass c't-Sim absolut bekackt 
@@ -50,7 +50,7 @@ public class Init {
 		}
 	}
 	
-	/** Metal-Design einstellen. */
+	/** Metal-Design einstellen */
 	private static void useMetalLookAndFeel() {
 		try {
 			UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");

--- a/ctSim/Init.java
+++ b/ctSim/Init.java
@@ -23,9 +23,7 @@ import javax.swing.UIManager;
 
 import ctSim.util.FmtLogger;
 
-/**
- * Initialisierungen für ct-Sim
- */
+/** Initialisierungen für ct-Sim */
 public class Init {
 	/** Logger */
 	static final FmtLogger lg = FmtLogger.getLogger("ctSim.controller.Init");

--- a/ctSim/MemoryLeakTest.java
+++ b/ctSim/MemoryLeakTest.java
@@ -26,11 +26,12 @@ import ctSim.controller.Main;
 
 /**
  * Test zum Untersuchen von Speicherlecks, wenn hintereinander viele
- * World-Objekte geladen werden. Als Hauptprogramm auszuführen.
+ * World-Objekte geladen werden. Ist als Hauptprogramm auszuführen.
  */
 public class MemoryLeakTest {
 	/**
 	 * main
+	 * 
 	 * @param args
 	 */
 	public static void main(String[] args) {
@@ -58,7 +59,7 @@ public class MemoryLeakTest {
 				try {
 					Thread.sleep(2000);
                 } catch (InterruptedException e) {
-                	// ist wurst
+                	// ist egal
                 }
 			}
         }

--- a/ctSim/MemoryLeakTest.java
+++ b/ctSim/MemoryLeakTest.java
@@ -26,7 +26,7 @@ import ctSim.controller.Main;
 
 /**
  * Test zum Untersuchen von Speicherlecks, wenn hintereinander viele
- * World-Objekte geladen werden. Ist als Hauptprogramm auszuführen.
+ * World-Objekte geladen werden. Ist als Hauptprogramm auszuführen...
  */
 public class MemoryLeakTest {
 	/**

--- a/ctSim/MemoryLeakTest.java
+++ b/ctSim/MemoryLeakTest.java
@@ -18,6 +18,7 @@
  */
 
 package ctSim;
+
 import java.io.File;
 
 import ctSim.controller.Controller;
@@ -40,9 +41,7 @@ public class MemoryLeakTest {
 		Main.main();
 	}
 
-	/**
-	 * Testklasse
-	 */
+	/** Testklasse */
 	public static class TestController extends DefaultController {
 		/**
 		 * @see ctSim.controller.DefaultController#onApplicationInited()

--- a/ctSim/SimBotTcpDump.java
+++ b/ctSim/SimBotTcpDump.java
@@ -18,6 +18,7 @@
  */
 
 package ctSim;
+
 import java.io.IOException;
 import java.net.ProtocolException;
 import java.net.ServerSocket;
@@ -40,6 +41,7 @@ import ctSim.model.Command;
 public class SimBotTcpDump {
 	/**
 	 * main
+	 * 
 	 * @param args
 	 * @throws Exception
 	 */
@@ -66,9 +68,7 @@ public class SimBotTcpDump {
 		}
 	}
 
-	/**
-	 * Forwarder-Thread
-	 */
+	/** Forwarder-Thread */
 	static class Forwarder extends Thread {
 		/** Quelle */
 		TcpConnection from;
@@ -81,6 +81,7 @@ public class SimBotTcpDump {
 
 		/**
 		 * Forwarder
+		 * 
 		 * @param name
 		 * @param from
 		 * @param to

--- a/ctSim/SimUtils.java
+++ b/ctSim/SimUtils.java
@@ -39,8 +39,7 @@ public class SimUtils {
 	 * Gradangabe und gibt sie als String zurück. Diese Methode wird zur Anzeige
 	 * der Bot-Blickrichtung im ControlPanel benutzt.
 	 * 
-	 * @param vec
-	 *            der Eingabevektor
+	 * @param vec	der Eingabevektor
 	 * @return die Gradzahl als String
 	 */
 	public static String vec3dToString(Vector3d vec) {
@@ -52,8 +51,7 @@ public class SimUtils {
 	 * Errechnet aus einem javax.vecmath.Vector3d eine Gradangabe. Diese Methode
 	 * wird zur Anzeige der Bot-Blickrichtung im ControlPanel benutzt.
 	 * 
-	 * @param vec
-	 *            der Eingabevektor
+	 * @param vec	der Eingabevektor
 	 * @return die (gerundete) Gradzahl als int-Wert
 	 */
 	public static double vec3dToDouble(Vector3d vec) {
@@ -72,8 +70,7 @@ public class SimUtils {
 	 * javax.vecmath.Vector3d. Diese Methode wird zum Setzen der
 	 * Bot-Blickrichtung über das ControlPanel benutzt.
 	 * 
-	 * @param deg
-	 *            der Winkel in Grad
+	 * @param deg	der Winkel in Grad
 	 * @return der neue Blickvektor
 	 */
 	public static Vector3d intToVec3d(int deg) {
@@ -91,8 +88,7 @@ public class SimUtils {
 	 * javax.vecmath.Vector3d. Diese Methode wird zum Setzen der
 	 * Bot-Blickrichtung über das ControlPanel benutzt.
 	 * 
-	 * @param deg
-	 *            der Winkel in Grad
+	 * @param deg	der Winkel in Grad
 	 * @return der neue Blickvektor
 	 */
 	public static Vector3d doubleToVec3d(double deg) {
@@ -120,8 +116,7 @@ public class SimUtils {
 	 * Errechnet den Winkel zwischen Nordrichtung des Universums (Richtung der 
 	 * positiven Y-Achse) und der angegeben Blickrichtung.
 	 * 
-	 * @param heading 
-	 * 			  Gib die Blickrichtung an, zu welcher der Winkel berechnet werden soll. 				 
+	 * @param heading	Gibt die Blickrichtung an, zu welcher der Winkel berechnet werden soll. 				 
 	 * @return Gibt den Winkel in Bogenmass (radians, Rad) zurück
 	 */
 	public static double getRotation(Vector3d heading) {
@@ -136,8 +131,9 @@ public class SimUtils {
 	
 	/**
 	 * Führt eine Transformation durch 
-	 * @param pos Position 
-	 * @param head Blickrichtung
+	 * 
+	 * @param pos	Position 
+	 * @param head	Blickrichtung
 	 * @return Die Transformation
 	 */
 	public static Transform3D getTransform(Point3d pos, Vector3d head) {
@@ -155,7 +151,8 @@ public class SimUtils {
 	
 	/**
 	 * Wandelt Millisekunden in die Anzeige h:m:s:ms um
-	 * @param millis Die Zeit in Millisekunden
+	 * 
+	 * @param millis	Die Zeit in Millisekunden
 	 * @return Die Zeit als Text
 	 */
 	public static String millis2time(long millis){

--- a/ctSim/TcpConnection.java
+++ b/ctSim/TcpConnection.java
@@ -41,6 +41,7 @@ public class TcpConnection extends Connection {
 
 	/**
 	 * TCP-Verbindung
+	 * 
 	 * @param sock	Socket
 	 * @throws IOException
 	 */
@@ -54,8 +55,8 @@ public class TcpConnection extends Connection {
 	 * Wandelt den übergebenen String und die Portnummer in eine TCP/IP-Adresse
 	 * und stellt dann die Verbindung her
 	 *
-	 * @param hostname Adresse als String
-	 * @param port Portnummer
+	 * @param hostname	Adresse als String
+	 * @param port		Portnummer
 	 * @throws IOException
 	 */
 	public TcpConnection(String hostname, int port) throws IOException {
@@ -64,6 +65,7 @@ public class TcpConnection extends Connection {
 
 	/**
 	 * Beendet die laufende Verbindung
+	 * 
 	 * @throws IOException
 	 */
 	@Override
@@ -90,6 +92,7 @@ public class TcpConnection extends Connection {
 
 	/**
 	 * Beginnt zu lauschen
+	 * 
 	 * @param receiver	Bot-Receiver
 	 */
 	public static void startListening(final BotReceiver receiver) {
@@ -124,6 +127,7 @@ public class TcpConnection extends Connection {
 
 	/**
 	 * Verbindet zu Host:Port
+	 * 
 	 * @param hostname	Host-Name des Bots
 	 * @param port		Port
 	 * @param receiver	Bot-Receiver
@@ -147,7 +151,7 @@ public class TcpConnection extends Connection {
 				} catch (IOException e) {
 					lg.severe(e, "E/A-Problem beim Verbinden mit "+address);
 				}
-				// Arbeit ist getan, ob's funktioniert hat oder nicht
+				// Arbeit ist getan, ob es funktioniert hat oder nicht...
 				die();
 			}
 		}.start();

--- a/ctSim/TestServer.java
+++ b/ctSim/TestServer.java
@@ -18,6 +18,7 @@
  */
 
 package ctSim;
+
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -45,42 +46,32 @@ public class TestServer implements Runnable {
 	public static final String  HOST        = "localhost";
 	public static final int     PORT        = 10001;
 	
-	/** 
-	 * Content, der hin und her geschickt wird...
-	 * 
-	 */
+	/** Content, der hin und her geschickt wird... */
 	public static final String  CONTENT     = "Test";
 	
 	/**
 	 * Will man einen Java-Client?
-	 * 
 	 * Ansonsten C-Client "von Hand" starten...
-	 * 
 	 */
 	public static final boolean JAVA_CLIENT = true;
 	
 	/** 
 	 * Wie oft soll der Java-Client "flushen"?
-	 * 
 	 * Wenn TRUE, dann jedes byte, sonst
 	 * ca. jedes "Command"...
-	 * 
 	 */
 	public static final boolean FLUSH_ALL   = false;
 	
 //	/** 
 //	 * TRUE: Server -> Client -> Server
 //	 * FALSE: Client -> Server -> Client
-//	 * 
 //	 */
 //	public static final boolean SERVER_TIME = true;
 	
 	/** 
 	 * Soll der Server einen Worker-Thread
 	 * benutzen, der den Ctrl. im Sim simuliert?
-	 * 
 	 * (synchronisiert wie im Sim der Ctrl.)
-	 * 
 	 */
 	public static final boolean USE_WORKER  = true;
 	
@@ -88,7 +79,6 @@ public class TestServer implements Runnable {
 	 * Wie lange der Worker pro Zyklus warten soll,
 	 * bevor er den Com-Thread wieder laufen lässt
 	 * (simuliert Arbeit des Ctrl.)
-	 * 
 	 */
 	public static final long    WORKER_WAIT = 100;
 	
@@ -96,7 +86,6 @@ public class TestServer implements Runnable {
 	 * Tick-Rate im Simulator: Jede Runde wird
 	 * mindestens diese Zeit gewartet
 	 * (+ simulierte Arbeit -- s.o.)
-	 * 
 	 */
 	public static final long    TICK_RATE   = 10;
 	
@@ -113,7 +102,6 @@ public class TestServer implements Runnable {
 	 * 
 	 * Nach einem Empfangs-/Sende-Vorgang wird auf den Worker
 	 * (wenn eingestellt über USE_WORKER) gewartet...
-	 * 
 	 */
 	class ServerCom
 			extends Connection
@@ -154,18 +142,13 @@ public class TestServer implements Runnable {
 		}
 		
 		public void start() {
-			
 			this.thrd = new Thread(this);
-			
 			this.thrd.start();
 		}
 		
 		public void stop() {
-			
 			Thread dummy = this.thrd;
-			
 			this.thrd = null;
-			
 			dummy.interrupt();
 		}
 		
@@ -176,7 +159,7 @@ public class TestServer implements Runnable {
 			System.out.println("Connection wurde hergestellt...");
 			
 			try {
-				send((new Command(Command.CMD_WELCOME, 0,	0, 0)).getCommandBytes());
+				send((new Command(Command.CMD_WELCOME, 0, 0, 0)).getCommandBytes());
 				System.out.println("Willkommen gesendet...");
 			} catch (IOException e2) {
 				e2.printStackTrace();
@@ -217,15 +200,15 @@ public class TestServer implements Runnable {
 //						
 //						if (str != null)
 //							System.out.println(String.format("SERVER: Antwort nach " +
-//															//"%9d ns", (System.nanoTime()-time)));
-//															"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
+//								// "%9d ns", (System.nanoTime()-time)));
+//								"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
 //						else
 //							//throw (new IOException("Stream ends here or connection broken"));
 //							break;
 //						
 //					} else {
 //						this.out.println(this.in.readLine());
-//					}
+//						}
 					
 					long time = System.nanoTime();
 					
@@ -233,8 +216,8 @@ public class TestServer implements Runnable {
 					receiveCommands();
 					
 					System.out.println(String.format("SERVER: Antwort nach " +
-							//"%9d ns", (System.nanoTime()-time)));
-							"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
+						//"%9d ns", (System.nanoTime()-time)));
+						"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
 					
 					if(this.worker != null)
 						this.worker.waitOnWorker();
@@ -266,7 +249,7 @@ public class TestServer implements Runnable {
 			System.exit(-1);
 		}
 		
-		// Erweiterung f�r Connection-Ged�ns aus dem Bot:
+		// Erweiterung für Connection-Gedöns aus dem Bot:
 		
 		// Kopiert aus Connection:
 		public void send(byte sendByte[]) throws IOException {
@@ -288,7 +271,7 @@ public class TestServer implements Runnable {
 			in.readFully( b, 0, len);
 		}
 		
-		// Connection-Ged�ns aus dem Bot
+		// Connection-Gedöns aus dem Bot
 		private int seq = 0;
 		
 		private synchronized void transmitSensors() {
@@ -384,7 +367,8 @@ public class TestServer implements Runnable {
 
 				
 //				lastTransmittedSimulTime= (int)world.getSimulTime();
-//				lastTransmittedSimulTime %= 10000;	// Wir haben nur 16 Bit zur Verfügung und 10.000 ist ne nette Zahl ;-)
+//				lastTransmittedSimulTime %= 10000;
+				// Wir haben nur 16 Bit zur Verfügung und 10.000 ist ne nette Zahl ;-)
 				command.setCommand(Command.CMD_DONE);
 //				command.setDataL(lastTransmittedSimulTime);
 				command.setDataL(10);
@@ -407,13 +391,12 @@ public class TestServer implements Runnable {
 			while (run==0) {
 				try {
 					Command command = new Command();
-					
 					valid = command.readCommand(this);
 					
-					if (valid == 0) {// Kommando ist in Ordnung
+					if (valid == 0) {	// Kommando ist in Ordnung
 						run = storeCommand(command);
 					} else
-						System.out.println("Ungueltiges Kommando"); //$NON-NLS-1$
+						System.out.println("Ungueltiges Kommando");	// $NON-NLS-1$
 				} catch (IOException e) {
 					lg.severe(e, "Verbindung unterbrochen -- Bot stirbt");
 //					die();
@@ -428,16 +411,13 @@ public class TestServer implements Runnable {
 		public int storeCommand(Command command) {
 			int result=0;
 			synchronized (commandBuffer) {
-				
 				commandBuffer.add(command);
 				
-				if (command.getCommand() ==  Command.CMD_DONE){ 
+				if (command.getCommand() == Command.CMD_DONE){ 
 					
-					//if (command.getDataL() == lastTransmittedSimulTime){
+					// if (command.getDataL() == lastTransmittedSimulTime){
 					if (command.getDataL() == 10){
-						
 						result = 1;
-						
 						waitForCommands.countDown();
 					}
 				}
@@ -460,7 +440,7 @@ public class TestServer implements Runnable {
 	 * machen darf).
 	 * 
 	 * Über TICK_RATE wird eine mindest (Bot-)Laufzeit eingestellt.
-	 * Der Worker schläft diese, nachdem er die 'ServerCom' (entspr. einem Bot)
+	 * Der Worker schläft diese, nachdem er die 'ServerCom' (entspricht einem Bot)
 	 * wieder freigegeben hat. Ein neuer Zyklus (in diesem Fall Sende-Vorgang)
 	 * kann also nicht vor Ablauf dieser Zeit _wieder_ beginnen (aber der
 	 * Bot kann während dieser Zeit rechnen; in diesem Fall die ServerCom
@@ -476,38 +456,26 @@ public class TestServer implements Runnable {
 		private CountDownLatch done  = new CountDownLatch(1);
 		
 		public void start() {
-			
 			this.thrd = new Thread(this);
-			
 			this.thrd.start();
 		}
 		
 		public void stop() {
-			
 			Thread dummy = this.thrd;
-			
 			this.thrd = null;
-			
 			dummy.interrupt();
 		}
 		
 		public void run() {
-			
 			Thread thisThrd = Thread.currentThread();
-			
 			System.out.println("Worker wurde gestartet...");
 			
 			while(this.thrd == thisThrd) {
-				
 				try {
 					this.done.await();
-					
 					Thread.sleep(TestServer.WORKER_WAIT);
-					
 					this.reinit();
-					
 					Thread.sleep(TestServer.TICK_RATE);
-				
 				} catch (InterruptedException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -517,26 +485,19 @@ public class TestServer implements Runnable {
 		
 		// Initialisiert Latches für den "nächsten" Zyklus
 		public synchronized void reinit() {
-			
 			CountDownLatch start = this.start;
-			
 			this.start = new CountDownLatch(1);
 			this.done  = new CountDownLatch(1);
-			
 			start.countDown();
 		}
 		
 		// Hier warten die Bots, bzw. die ServerCom auf den
 		// Ctrl., bzw. den Worker
-		public void waitOnWorker()
-				throws InterruptedException {
-			
+		public void waitOnWorker() throws InterruptedException {
 			CountDownLatch start = this.start;
 			// überflüssig ?
 			CountDownLatch done  = this.done;
-			
 			done.countDown();
-			
 			start.await();
 		}
 	}
@@ -555,7 +516,6 @@ public class TestServer implements Runnable {
 	 * 
 	 */
 	TestServer(int port) {
-		
 		try {
 			this.serverSocket = new ServerSocket(port);
 		} catch (IOException e) {
@@ -567,37 +527,26 @@ public class TestServer implements Runnable {
 	}
 	
 	public void start() {
-		
 		this.serverThrd = new Thread(this);
-		
 		this.serverThrd.start();
 	}
 	
 	public void stop() {
-		
 		Thread dummy = this.serverThrd;
-		
 		this.serverThrd = null;
-		
 		dummy.interrupt();
 	}
 
 	public void run() {
-		
 		Thread thisThrd = Thread.currentThread();
-		
 		System.out.println("Server ist hoch und rennen...");
 		
 		while(this.serverThrd == thisThrd) {
-			
 			try {
-				
 				this.clientSocket = this.serverSocket.accept();
-				
 				System.out.println("Connection wird hergestellt...");
 				ServerCom com = new ServerCom(this.clientSocket);
 				com.start();
-				
 			} catch (IOException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
@@ -615,18 +564,15 @@ public class TestServer implements Runnable {
 	
 	/**
 	 * main
+	 * 
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		
 		TestServer server = new TestServer(TestServer.PORT);
-		
 		server.start();
 		
 		if(TestServer.JAVA_CLIENT) {
-			
 			TestClient client = new TestClient(TestServer.HOST, TestServer.PORT);
-			
 			client.start();
 		}
 	}
@@ -636,7 +582,7 @@ public class TestServer implements Runnable {
  * Der TestClient schickt einfach ein ankommendes Datum zurück
  * an den Server, der dann die Zeit stoppt und ausgibt (SERVER_TIME).
  * 
- * Oder schickt ein Datum an den Server und wartet selbst bis
+ * Oder er schickt ein Datum an den Server und wartet selbst bis
  * dieses zurückkommt (SERVER_TIME == FALSE).
  * 
  */
@@ -646,11 +592,9 @@ class TestClient implements Runnable {
 	private Thread clientThrd;
 
 	PrintWriter out;
-
 	BufferedReader in;
 
 	TestClient(String host, int port) {
-
 		try {
 			this.socket = new Socket(host, port);
 			out = new PrintWriter(socket.getOutputStream(), true);
@@ -668,29 +612,22 @@ class TestClient implements Runnable {
 	}
 	
 	public void start() {
-		
 		this.clientThrd = new Thread(this);
-		
 		this.clientThrd.start();
 	}
 	
 	public void stop() {
-		
 		Thread dummy = this.clientThrd;
-		
 		this.clientThrd = null;
-		
 		dummy.interrupt();
 	}
 
 	public void run() {
-		
 		Thread thisThrd = Thread.currentThread();
-		
 		System.out.println("Client ist hoch und rennen...");
-		
 		System.out.println("Warten und Senden willkommen...");
 		int cmd = 0;
+		
 		while(cmd != 60) {
 			try {
 				cmd = this.in.read();
@@ -703,8 +640,8 @@ class TestClient implements Runnable {
 			}
 		}
 		int c = 1;
+		
 		while(this.clientThrd == thisThrd) {
-			
 			try {
 //				if(TestServer.SERVER_TIME) {
 //					this.out.println(this.in.readLine());
@@ -717,15 +654,15 @@ class TestClient implements Runnable {
 //					String str = this.in.readLine();
 //					
 //					System.out.println(String.format("CLIENT: Antwort nach " +
-//													//"%9d ns", (System.nanoTime()-time)));
-//													"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
+//						// "%9d ns", (System.nanoTime()-time)));
+//						"%4.3f ms", ((float) (System.nanoTime()-time)) / 1000000.));
 //				}
 				
 				int str = this.in.read();
-				//if(c==1) {
+// 				if(c==1) {
 				System.out.println(c+".: "+str);
 				this.out.write(str);
-				//}
+// 				}
 				if(TestServer.FLUSH_ALL || str == 60) {
 					this.out.flush();
 					c++;

--- a/ctSim/applet/Main.java
+++ b/ctSim/applet/Main.java
@@ -49,9 +49,7 @@ import ctSim.util.FmtLogger;
 import ctSim.util.IconProvider;
 import ctSim.view.gui.BotViewer;
 
-/**
- * Main-Klasse für das c't-Bot-Applet 
- */
+/** Main-Klasse für das c't-Bot-Applet */
 public class Main extends JApplet implements BotReceiver {
 	/** UID */
 	private static final long serialVersionUID = - 2381362461560258968L;
@@ -76,9 +74,8 @@ public class Main extends JApplet implements BotReceiver {
 	/** Controller-Referenz */
 	private Controller controller = null;
 
-	/**
-	 * Initialiserung des Applets
-	 */
+	
+	/** Initialiserung des Applets */
 	@Override
 	public void init() {
 		initLogging();
@@ -97,9 +94,7 @@ public class Main extends JApplet implements BotReceiver {
 		controller = new DefaultController();
 	}
 
-	/**
-	 * Logging initialisieren
-	 */
+	/** Logging initialisieren */
 	private void initLogging() {
 		FmtLogger.setFactory(new FmtLogger.Factory() {
 			@Override
@@ -135,27 +130,22 @@ public class Main extends JApplet implements BotReceiver {
 		mainLogger.addHandler(h);
 	}
 
-	/**
-	 * Icons initialisieren
-	 */
+	/** Icons initialisieren */
 	private void initIcons() {
 		Config.setIconProvider(new IconProvider() {
 			public Icon get(String key) {
-				// Icon aus jar-Datei laden; Annahme: jar enthält Icon in
-				// seinem Root-Verzeichnis
-				URL u = getClass().getClassLoader().getResource(key+".gif");//$$ images-unterverz
+				// Icon aus jar-Datei laden; Annahme: jar enthält Icon in seinem Root-Verzeichnis
+				URL u = getClass().getClassLoader().getResource(key+".gif");	// $$ images-unterverz
 				// NullPointerException vermeiden
 				if (u == null)
-					return new ImageIcon(); // leeres Icon
+					return new ImageIcon();	// leeres Icon
 				else
 					return new ImageIcon(u);
 			}
 		});
 	}
 
-	/**
-	 * Startet die TCP-Connection
-	 */
+	/** Startet die TCP-Connection */
 	@Override
 	public void start() {
 		int port;
@@ -170,7 +160,7 @@ public class Main extends JApplet implements BotReceiver {
 	}
 
 	/**
-* Fügt einen neuen (bereits erstellten) Bot in das Fenster ein
+	 * Fügt einen neuen (bereits erstellten) Bot in das Fenster ein
 	 * @param b	Referenz auf den neuen Bot
 	 */
 	public void onBotAppeared(final Bot b) {
@@ -205,7 +195,7 @@ public class Main extends JApplet implements BotReceiver {
 			}
 		});
 		bot = b;
-		/* Der Bot braucht nen Controller! */
+		/** Der Bot braucht einen Controller! */
 		try {
 			bot.setController(controller);
 		} catch (ProtocolException e) {
@@ -214,9 +204,7 @@ public class Main extends JApplet implements BotReceiver {
 		}
 	}
 
-	/**
-	 * Beendet das c't-Bot-Applet
-	 */
+	/** Beendet das c't-Bot-Applet */
 	@Override
 	public void destroy() {
 		SwingUtilities.invokeLater(new Runnable() {
@@ -225,6 +213,6 @@ public class Main extends JApplet implements BotReceiver {
 					bot.dispose();
 				mainLogger.info("c't-Bot-Applet wird beendet");
 			}
-		});
+		} );
 	}
 }

--- a/ctSim/controller/BotBarrier.java
+++ b/ctSim/controller/BotBarrier.java
@@ -25,6 +25,7 @@ package ctSim.controller;
 public interface BotBarrier {
 	/**
 	 * Wartet auf die nächste Runde
+	 * 
 	 * @throws InterruptedException
 	 */
 	public void awaitNextSimStep() throws InterruptedException;

--- a/ctSim/controller/BotReceiver.java
+++ b/ctSim/controller/BotReceiver.java
@@ -26,8 +26,9 @@ import ctSim.model.bots.Bot;
  */
 public interface BotReceiver {
 	/**
-	 * Handler für neuer Bot da
-	 * @param b Bot
+	 * Handler für neuer Bot ist da
+	 * 
+	 * @param b	Bot
 	 */
 	public void onBotAppeared(Bot b);
 }

--- a/ctSim/controller/Config.java
+++ b/ctSim/controller/Config.java
@@ -45,19 +45,18 @@ import ctSim.util.xml.XmlDocument;
 
 /**
  * Managed die Konfiguration des ct-Sim
- * Theoretisch kann man mehr als einmal initialisieren (Konfig laden), aber das ist ungetestet
+ * Theoretisch kann man mehr als einmal initialisieren (Konfig laden), aber das ist ungetestet.
  */
 public class Config {
-	/**
-	 * für Dateien
-	 */
+	/** für Dateien */
 	public static class SourceFile extends File {
 		/** UID */
 		private static final long serialVersionUID = 3022935037996253818L;
 
 		/**
 		 * Neues Dateihandle
-		 * @param pathAndName Pfad
+		 * 
+		 * @param pathAndName	Pfad
 		 */
 		public SourceFile(String pathAndName) {
 			super(pathAndName);
@@ -78,7 +77,7 @@ public class Config {
 	static final String[] parameterFallbacks = {
 		"botport", "10001",
 		"judge", "ctSim.model.rules.DefaultJudge",
-		"worlddir", ".", //$$ besser dokumentieren in ct-sim.xml und Co.
+		"worlddir", ".", // TODO: besser dokumentieren in ct-sim.xml und Co.
 		"botdir", ".",
 		"useContestConductor", "false",
 		"contestBotTargetDir", "tmp",
@@ -103,7 +102,7 @@ public class Config {
 	};
 
 	/** <p>Enthält die Einzelparameter der Konfiguration (spiegelt also
-	 * die <code>&lt;parameter></code>-Tags wider)</p>
+	 * die <code><parameter></code>-Tags wider)</p>
 	 *
 	 * <p>Verwendung: Wird zunächst auf die Default-Werte gesetzt, die aus
 	 * dem hartkodierten Array <code>configDefaults</code> kommen. Beim
@@ -122,8 +121,8 @@ public class Config {
 	 * Lädt die <code>&lt;parameter></code>-Tags aus der
 	 * Konfigurationsdatei des Sims. Die Werte der Tags sind dann mittels
 	 * {@link #getValue(String)} verfügbar.
-	 * @param file Konfigurationsdatei dem von "config/config.dtd"
-	 * vorgeschriebenen XML-Format.
+	 * 
+	 * @param file	Konfigurationsdatei dem von "config/config.dtd" vorgeschriebenen XML-Format.
 	 * @throws ParserConfigurationException
 	 * @throws IOException
 	 * @throws SAXException
@@ -143,7 +142,8 @@ public class Config {
 
 	/**
 	 * Lädt Icons
-	 * @param iconsBaseDirectory Verzeichnis
+	 * 
+	 * @param iconsBaseDirectory	Verzeichnis
 	 * @throws NullPointerException
 	 * @throws FileNotFoundException
 	 * @throws IllegalArgumentException
@@ -173,9 +173,9 @@ public class Config {
 	}
 
 	/**
-	 * @param botType	Bot-Typ
-	 * @param index		Bot-Nummer
-	 * @param appearanceType Appearance
+	 * @param botType			Bot-Typ
+	 * @param index				Bot-Nummer
+	 * @param appearanceType	Appearance
 	 * @return Farbe
 	 */
 	public static Color getBotColor(Class<?> botType, int index,
@@ -191,20 +191,18 @@ public class Config {
 		URL u = ClassLoader.getSystemResource("images/" + key+".gif");
 		// NullPointerException vermeiden
 		if (u == null)
-			return new ImageIcon(); // leeres Icon
+			return new ImageIcon();	// leeres Icon
 		else
 			return new ImageIcon(u);		
 	}
 
-	/**
-	 * HashMap für Plain-Parameter
-	 */
+	/** HashMap für Plain-Parameter */
 	static class PlainParameters extends HashMap<String, String> {
 		/** UID */
 		private static final long serialVersionUID = - 6931464910390788433L;
 
 		/**
-		 * Lädt die <code>&lt;parameter&gt;</code>-Tags aus der
+		 * Lädt die <code><parameter></code>-Tags aus der
 		 * Konfigurationsdatei des Sims. Die Werte der Tags sind dann mittels
 		 * get(String) verfügbar.
 		 * @param doc Config-Dokument
@@ -239,17 +237,13 @@ public class Config {
 		}
 	}
 
-	/**
-	 * Hash-Map für Bot-Appearances
-	 */
+	/** Hash-Map für Bot-Appearances */
 	static class BotAppearances
 	extends HashMap<BotAppearances.AppearanceKey, List<Color>> {
 		/** UID */
 		private static final long serialVersionUID = 8690190797733423514L;
 
-		/**
-		 * Appearance-Key
-		 */
+		/** Appearance-Key */
 		class AppearanceKey {
 			/** Bot-Typ */
 			final Class<?> botType;
@@ -258,6 +252,7 @@ public class Config {
 
 			/**
 			 * Neue Appearance
+			 * 
 			 * @param botType			Bot-Typ
 			 * @param appearanceType	Appearance
 			 */
@@ -268,7 +263,8 @@ public class Config {
 			}
 
 			/**
-			 * Wichtig, weil wir's als Schlüssel in der Map verwenden
+			 * Wichtig, weil wir es als Schlüssel in der Map verwenden
+			 * 
 			 * @see java.lang.Object#equals(java.lang.Object)
 			 */
 			@Override
@@ -288,22 +284,24 @@ public class Config {
 			}
 
 			/**
-			 * Wichtig, weil wir's als Schlüssel in der Map verwenden
+			 * Wichtig, weil wir es als Schlüssel in der Map verwenden
 			 * Implementiert nach Josh Bloch: "Effective Java",
-			 * http://developer.java.sun.com/developer/Books/effectivejava/Chapter3.pdf
+			 * (http://developer.java.sun.com/developer/Books/effectivejava/Chapter3.pdf)
+			 * 
 			 * @see java.lang.Object#hashCode()
 			 */
 			@Override
 			public int hashCode() {
-				int rv = 17; // beliebiger Wert
-				rv = 37 * rv + hash(botType); // 37: ungerade Primzahl
+				int rv = 17;	// beliebiger Wert
+				rv = 37 * rv + hash(botType);	// 37: ungerade Primzahl
 				rv = 37 * rv + hash(appearanceType);
 				return rv;
 			}
 
 			/**
 			 * Hashwert des Objekts berechnen
-			 * @param o Objekt
+			 * 
+			 * @param o	Objekt
 			 * @return Hashwert
 			 */
 			private int hash(Object o) {
@@ -312,7 +310,7 @@ public class Config {
 		}
 
 		/**
-		 * @param d Document
+		 * @param d	Document
 		 */
 		BotAppearances(QueryableDocument d) {
 			try {
@@ -334,15 +332,16 @@ public class Config {
 					}
 				}
 			} catch (XPathExpressionException e) {
-				// Kann nur passieren, wenn einer was am Code ändert
+				// Kann nur passieren, wenn einer etwas am Code ändert
 				throw new AssertionError(e);
 			}
 		}
 
 		/**
 		 * Lädt Appearances
-		 * @param botTag Tag
-		 * @param botType Typ
+		 * 
+		 * @param botTag	Tag
+		 * @param botType	Typ
 		 * @throws XPathExpressionException
 		 */
 		private void loadAppearances(QueryableNode botTag, Class<?> botType)
@@ -356,7 +355,7 @@ public class Config {
 		}
 
 		/**
-		 * @param classNameFromXml Klasse als XML
+		 * @param classNameFromXml	Klasse als XML
 		 * @return Klasse
 		 * @throws ClassNotFoundException
 		 */
@@ -364,7 +363,7 @@ public class Config {
 		throws ClassNotFoundException {
 			// 1. Versuch
 			if ("default".equals(classNameFromXml))
-				return null; // Default-Wert wird mit null ausgedrückt
+				return null;	// Default-Wert wird mit null ausgedrückt
 
 			// 2. Versuch
 			try { return getClassTolerateNumber(classNameFromXml); }
@@ -381,9 +380,10 @@ public class Config {
 		}
 
 		// Das alte Format erlaubte z.B. "CtBotSimTcp_3";
-		// probieren wir's ohne Unterstrich und Nummer
+		// probieren wir es ohne Unterstrich und Nummer
+		
 		/**
-		 * @param classNameFromXml Klasse als XML
+		 * @param classNameFromXml	Klasse als XML
 		 * @return Klasse
 		 * @throws ClassNotFoundException
 		 */
@@ -394,13 +394,14 @@ public class Config {
 			catch (ClassNotFoundException e) { /* weitermachen */ }
 
 			// 2. Versuch: Ohne Anhängsel
-			return Class.forName(classNameFromXml.split("_")[0]); //$$ XML anpassen
+			return Class.forName(classNameFromXml.split("_")[0]);	// $$ XML anpassen
 		}
 
 		/**
-* Fügt eine Appearance hinzu
-		 * @param key Schlüssel
-		 * @param value Farbe
+		 * Fügt eine Appearance hinzu
+		 * 
+		 * @param key	Schlüssel
+		 * @param value	Farbe
 		 */
 		void add(AppearanceKey key, Color value) {
 			if (! containsKey(key))
@@ -419,9 +420,9 @@ public class Config {
 		 * <li>Index 4: Grün</li>
 		 * <li>usw. </li>
 		 * </ul>
-		 * @param botType Bot-Typ
-		 * @param appearanceType Appearance-Typ
-		 * @param index Nr
+		 * @param botType			Bot-Typ
+		 * @param appearanceType	Appearance-Typ
+		 * @param index				Nummer
 		 * @return Farbe
 		 */
 		Color get(Class<?> botType, String appearanceType, int index) {
@@ -448,9 +449,7 @@ public class Config {
 		}
 	}
 
-	/**
-	 *Parameter-Typen
-	 */
+	/** Parameter-Typen */
 	static class ParameterType {
 		/** Name */
 		final String name;
@@ -459,6 +458,7 @@ public class Config {
 
 		/**
 		 * Parameter-Typ
+		 * 
 		 * @param name	Name
 		 * @param type	Typ
 		 */

--- a/ctSim/controller/Controller.java
+++ b/ctSim/controller/Controller.java
@@ -32,7 +32,7 @@ import ctSim.view.View;
 
 /**
  * <p>
- * Interface, das die Views der Applikation verwenden, um auf den Controller
+ * Interface, das die Views der Applikation verwendet, um auf den Controller
  * zuzugreifen. ("View" und "Controller" sind dabei im Sinne von <a
  * href="http://en.wikipedia.org/wiki/Model-view-controller"
  * target="_blank">MVC</a> zu verstehen.)
@@ -41,38 +41,35 @@ import ctSim.view.View;
  * Das Interface definiert also in erster Linie, welche Dienste ein Controller
  * den Views der Applikation zur Verfügung stellt. Daneben hat das
  * Interface die offensichtliche Bedeutung, dass der Controller der Applikation
- * gegenüber den Views (ausschließlich) unter diesem Interface
- * erscheint.
+ * gegenüber den Views (ausschließlich) unter diesem Interface erscheint.
  * </p>
  *
  * @see View
- * @author Hendrik Krauss &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * 
+ * @author Hendrik Krauß (hkr@heise.de)
  */
 public interface Controller {
 	/**
-	 * @param view das neue View
+	 * @param view	das neue View
 	 */
 	public void setView(View view);
 
-	/**
-	 * Schliesst die Welt
-	 */
+	/** Schliesst die Welt */
 	public void closeWorld();
 	
 	/**
 	 * Startet einen externen Bot
 	 *
-	 * @param file Zeigt auf die Binary des Bots
+	 * @param file	Zeigt auf die Binary des Bots
 	 */
 	public void invokeBot(File file);
 
-	/**
-* Fügt einen Testbot hinzu
-	 */
+	/** ügt einen Testbot hinzu */
 	public void addTestBot();
 
 	/**
 	 * Verbindet zu einem Bot
+	 * 
 	 * @param hostname	Host
 	 * @param port		Port
 	 */
@@ -80,91 +77,92 @@ public interface Controller {
 
 	/**
 	 * Lädt eine Welt aus einer Datei
+	 * 
 	 * @param sourceFile Weltdatei
 	 */
 	public void openWorldFromFile(File sourceFile);
 
 	/**
 	 * Lädt eine Welt aus einem XML-formatierten String
-	 * @param parcoursAsXml Welt als XML-String
+	 * 
+	 * @param parcoursAsXml	Welt als XML-String
 	 */
 	public void openWorldFromXmlString(String parcoursAsXml);
 
-	/**
-	 * Lädt eine zufällig generierte Welt
-	 */
+	/** Lädt eine zufällig generierte Welt */
 	public void openRandomWorld();
 
 	/**
 	 * Setzt den Schiedsrichter
+	 * 
 	 * @param judgeClassName
 	 */
 	public void setJudge(String judgeClassName);
 
 	/**
 	 * Setzt den Schiedsrichter
+	 * 
 	 * @param j
 	 */
 	public void setJudge(Judge j);
 
-	/**
-	 * Hält die Simulation für unbestimmte Zeit an
-	 */
+	/** Hält die Simulation für unbestimmte Zeit an */
 	public void pause();
 
-	/**
-	 * Setzt die Simulation fort
-	 */
+	/** Setzt die Simulation fort */
 	public void unpause();
 
 	/**
-	 * Von außen, d.h. von einer Bootstrap-Komponente, aufzurufen, sobald
+	 * Von außen, d.h. von einer Bootstrap-Komponente, aufrufen, sobald
 	 * die Hauptkomponenten der Applikation (Controller und View) initialisiert
 	 * und untereinander korrekt verdrahtet sind. Ab diesem Methodenaufruf liegt
 	 * die Verantwortung für den Programmablauf beim Controller.
 	 */
 	void onApplicationInited();
 	
-	/**
-     * Setzt alle Bots zurück
-     */
+	/** Setzt alle Bots zurück */
     public void resetAllBots();
 	
 	/**
 	 * Liefert ein Kommando an einen Bot aus.
 	 * Diese Routine kann dazu benutzt werden, um Bot-2-Bot-Kommunikation zu betreiben
-	 * Sender und Empfänger stehen in dem Command drin 
-	 * @param command das zu übertragende Kommando
-	 * @throws ProtocolException Falls kein passender Empfänger gefunden wurde
+	 * Sender und Empfänger stehen in dem Command drin.
+	 * 
+	 * @param command	das zu übertragende Kommando
+	 * @throws ProtocolException	Falls kein passender Empfänger gefunden wurde
 	 */
 	public void deliverMessage(Command command) throws ProtocolException;
 	
 	/**
 	 * Liefert eine Id aus dem Adresspoll zurück
+	 * 
 	 * @return Die neue Id
-	 * @throws ProtocolException Wenn keine Adresse mehr frei
+	 * @throws ProtocolException	Wenn keine Adresse mehr frei
 	 */
 	public BotID generateBotId() throws ProtocolException;
 	
 	/**
 	 * Testet, ob bereits ein Bot diese Id hat
-	 * @param id zu testende Id
+	 * 
+	 * @param id	zu testende Id
 	 * @return True, wenn noch kein Bot diese Id nutzt 
 	 */
 	public boolean isIdFree(BotID id);
 	
 	/**
-	 * Exportiert die aktuelle Welt in eine Bot-Map-Datei 
-	 * @param bot Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
-	 * @param free Wert, mit dem freie Felder eingetragen werden (z.B. 100)
-	 * @param occupied Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
-	 * @throws IOException falls Fehler beim Schreiben der Datei
-	 * @throws MapException falls keine Daten in der Map
+	 * Exportiert die aktuelle Welt in eine Bot-Map-Datei
+	 * 
+	 * @param bot		Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
+	 * @param free		Wert, mit dem freie Felder eingetragen werden (z.B. 100)
+	 * @param occupied	Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
+	 * @throws IOException	falls Fehler beim Schreiben der Datei
+	 * @throws MapException	falls keine Daten in der Map
 	 */
 	public void worldToMap(int bot, int free, int occupied) throws IOException, MapException;
 	
 	/**
 	 * gibt die aktuelle Welt zurück
+	 * 
 	 * @return geladenen Welt
 	 */
 	public World getWorld();

--- a/ctSim/controller/DefaultController.java
+++ b/ctSim/controller/DefaultController.java
@@ -51,9 +51,7 @@ import ctSim.util.FmtLogger;
 import ctSim.util.Misc;
 import ctSim.view.View;
 
-/**
- * Zentrale Controller-Klasse des c't-Sim
- */
+/** Zentrale Controller-Klasse des c't-Sim */
 public class DefaultController
 implements Controller, BotBarrier, Runnable, BotReceiver {
 	/** Logger */
@@ -73,7 +71,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     private View view;
     /** Welt */
     private World world;
-    /** Thread, der die Simulation macht: Siehe {@link #run()}. */
+    /** Thread, der die Simulation macht: Siehe {@link #run()} */
     private Thread sequencer;
 
 	/** Bots */
@@ -81,8 +79,10 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /** Flag für Bot-Reset */
 	private boolean reset = false;
+	
     /**
      * Setzt das View und initialisiert alles Nötige dafür
+     * 
      * @param view	unser View
      */
     public void setView(View view) {
@@ -103,9 +103,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
         }
     }
 
-    /**
-     * Initialiserung
-     */
+    /** Initialiserung */
     private void init() {
         try {
             String parcFile = Config.getValue("parcours");
@@ -137,11 +135,11 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 	 * erledigt er pro Simschritt zwei Hauptaufgaben:
 	 * <ul>
 	 * <li>"updateSimulation": Sagt der Welt bescheid, die den ThreeDBots
-	 * bescheidsagt, die den Simulatoren bescheidsagen. Die Simulation rechnen
-	 * einen Simschritt, z.B. wird abhängig von der Motorgeschwindigkeit
+	 * bescheid sagt, die den Simulatoren bescheidsagen. Die Simulation rechnen
+	 * einen Sim-Schritt, z.B. wird abhängig von der Motorgeschwindigkeit
 	 * die Position des Bot weitergesetzt</li>
 	 * <li>Die Bots übertragen die Sensordaten zum C-Code, warten auf
-	 * Antwort, und verarbeiten die Antwort. </li>
+	 * Antwort, und verarbeiten die Antwort.</li>
 	 * </ul>
 	 */
 	public void run() {
@@ -168,8 +166,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 	        try {
 				long realTimeBeginInMs = System.currentTimeMillis();
 
-				// Warte, bis alle Bots fertig sind und auf die nächste
-	        	// Aktualisierung warten
+				// Warte, bis alle Bots fertig sind und auf die nächste Aktualisierung warten
 				// breche ab, wenn die Bots zu lange brauchen !
 				if(! doneSignal.await(timeout, TimeUnit.MILLISECONDS)) {
 					lg.warn("Bot-Probleme: Ein oder mehrere Bots waren " +
@@ -194,7 +191,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 					view.onSimulationFinished();
 				}
 
-				// View(s) bescheidsagen
+				// den View(s) bescheid sagen
 				view.onSimulationStep(sequencersWorld.getSimTimeInMs());
 
 				if(this.pause) {
@@ -214,8 +211,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 					pause();
 				}
 
-				// Add/Start new Bot
-				// + neue Runde einleuten
+				// Add/Start new Bot + neue Runde einläuten
 				// überschreibt startSignal, aber wir haben mit oldStartSignal
 				// eine Referenz aufgehoben
 				doneSignal  = new CountDownLatch(sequencersWorld
@@ -235,9 +231,9 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 					Thread.sleep(timeToSleep);
 	        } catch (InterruptedException e) {
 	            // Wird von wait() geworfen, wenn jemand closeWorld() macht
-				// während wait() noch läuft (closeWorld() ruft interrupt()
-				// auf). Man bittet uns, unsere while-Bedingung auszuwerten,
-				// weil die false geworden ist. Also normal weitergehen
+				// während wait() noch läuft (closeWorld() ruft interrupt() auf).
+	        	// Man bittet uns, unsere while-Bedingung auszuwerten,
+				// weil die false geworden ist. Also normal weitergehen.
 	        }
 	    }
 		sequencersWorld.cleanup();
@@ -264,16 +260,13 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 		this.pause = true;
 	}
 
-	/**
-	 * Beendet die Pause des Sequencers (= der Simulation)
-	 */
+	/** Beendet die Pause des Sequencers (= der Simulation) */
 	public synchronized void unpause() {
 		lg.fine("Pausenende angefordert");
 		if(this.world == null)
 			return;
 
-		// Wenn world != null haben wir einen Sequencer-Thread laufen
-
+		/** Wenn world != null haben wir einen Sequencer-Thread laufen */
 		if(this.pause && this.judge.isStartingSimulationAllowed()) {
 			this.pause = false;
 			this.notify();
@@ -284,27 +277,28 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 	 * Setzt die Welt. Prinzip: Sequencer und Welt werden gemeinsam erstellt und
 	 * gemeinsam gekillt. setWorld() startet einen Sequencer-Thread, der
 	 * pausiert bleibt bis jemand unpause() aufruft.
-	 * @param world Die Welt
+	 * 
+	 * @param world	Die Welt
 	 */
 	private void setWorld(World world) {
 		if (world == null)
 			throw new NullPointerException();
 
-		closeWorld(); // Beendet Thread
+		closeWorld();	// Beendet Thread
 		this.world = world;
 		judge.setWorld(world);
 		view.onWorldOpened(world);
 		lg.info("Neue Welt geöffnet");
 
 		lg.fine("Initialisiere Sequencer");
-		pause = true; // Immer pausiert starten
+		pause = true;	// Immer pausiert starten
 		sequencer = new Thread(this, "ctSim-Sequencer");
 		sequencer.start();
     }
 
 	/** Hält den Sequencer-Thread an */
     public void closeWorld() {
-    	if (sequencer == null) // Keine Welt geladen, d.h. kein Sequencer läuft
+    	if (sequencer == null)	// Keine Welt geladen, d.h. kein Sequencer läuft
     		return;
 
     	lg.fine("Terminieren des Sequencer angefordert");
@@ -319,6 +313,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /**
      * Verbindet zu Host:Port
+     * 
      * @param hostname	Ziel der Verbindung (Name)
      * @param port		Ziel der Verbindung (Port)
      */
@@ -332,9 +327,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     	}
     }
 
-    /**
-     * Fügt der Welt einen neuen Bot der Klasse CtBotSimTest hinzu
-     */
+    /** Fügt der Welt einen neuen Bot der Klasse CtBotSimTest hinzu */
     public void addTestBot() {
     	if (sequencer == null) {
     		try {
@@ -357,6 +350,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /**
      * Startet einen externen Bot
+     * 
      * @param file	File-Objekt des Bots
      */
 	public void invokeBot(File file) {
@@ -365,6 +359,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
 	/**
 	 * Startet einen externen Bot
+	 * 
 	 * @param filename	Pfad zum Bot als String
 	 */
     public void invokeBot(String filename) {
@@ -377,14 +372,14 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     		if (System.getProperty("os.name").indexOf("Linux") >= 0){
     			Process p = Runtime.getRuntime().exec(
     				new String[] { "chmod", "ugo+x", filename });
-    			p.waitFor(); // Warten bis der gelaufen ist
+    			p.waitFor();	// Warten bis der gelaufen ist
     			if (p.exitValue() != 0) {
     				lg.warning("Fehler beim Setzen der execute-Permission: " +
     						"chmod lieferte %d zurück", p.exitValue());
     			}
     		}
     		// Bot ausführen
-    		// String[] weil sonst trennt er das nach dem ersten Leerzeichen ab,
+    		// String[], sonst trennt er das nach dem ersten Leerzeichen ab,
     		// dann geht's nicht, wenn der Pfad mal ein Leerzeichen enthält
     		File dir = new File(filename).getAbsoluteFile().getParentFile();
             Runtime.getRuntime().exec(new String[] { filename }, null, dir);
@@ -395,6 +390,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /**
      * Handler, falls ein Bot stirbt
+     * 
      * @param bot	Der sterbende Bot
      */
     public synchronized void onBotDisappeared(Bot bot) {
@@ -412,6 +408,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     
     /**
 	 * Handler, falls neuer Bot hinzugefügt wurde
+	 * 
 	 * @param bot	Der neue Bot
 	 */
 	public synchronized void onBotAppeared(final Bot bot) {
@@ -420,18 +417,18 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 				lg.info("Weise " + bot.toString()
 						+ " ab: Es gibt keine Welt, zu "
 						+ "der man ihn hinzufügen könnte");
-				bot.dispose(); // Bot abweisen
+				bot.dispose();	// Bot abweisen
 				return;
 			}
 			if (judge.isAddingBotsAllowed()) {
 				Bot b = world.addBot((SimulatedBot) bot, this);
 				if (b == null) {
-					bot.dispose(); // Bot abweisen, weil kein Platz mehr
+					bot.dispose();	// Bot abweisen, da kein Platz mehr
 					return;
 				}
 				view.onBotAdded(b);
 			} else {
-				bot.dispose(); // Bot abweisen
+				bot.dispose();	// Bot abweisen
 			}
 		} else
 			view.onBotAdded(bot);
@@ -442,12 +439,12 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 			lg.severe("Fehler: Bot " + bot.toString()
 					+ " wurde vom Controller abgewiesen! Bot-ID falsch?");
 			SwingUtilities.invokeLater(new Runnable() {
-				public void run() { // invokeLater, weil sonst der
+				public void run() {	// invokeLater, weil sonst der
 					// dispose-Listener der GUI noch nicht eingetragen ist!
-					bot.dispose(); // Bot ist unerwünscht => weg
+					bot.dispose();	// Bot ist unerwünscht => weg
 				}
 			});
-			return; // keine Exception, wir weisen den Bot einfach ab und
+			return;	// keine Exception, wir weisen den Bot einfach ab und
 			// alles andere läuft normal weiter
 		}
 
@@ -465,6 +462,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /**
      * Gibt die Anzahl der zurzeit geladenen Bots zurück
+     * 
      * @return	Anzahl der Bots
      */
     public int getParticipants() {
@@ -472,11 +470,12 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     }
 
     /**
-     * @param judgeClassName Die Art des Schiedrichters zu setzen
-     * Stellt sicher, dass immer ein sinnvoller Judge gesetzt ist
+     * @param judgeClassName	Die Art des Schiedrichters zu setzen
+     * 
+     * Stellt sicher, dass immer ein sinnvoller Judge gesetzt ist.
      */
     public void setJudge(String judgeClassName) {
-    	/* Kein Jugde-Wechsel, wenn eine Welt offen ist */
+    	/* Kein Jugde-Wechsel wenn eine Welt offen ist */
     	if (sequencer != null) {
     		lg.info("Kein Wechsel erlaubt, weil noch eine Welt offen ist");
     		return;
@@ -495,11 +494,12 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
             return;
         }
 
-        setJudge(j); // wird nur erreicht, wenn der try-Block geklappt hat
+        setJudge(j);	// wird nur erreicht, wenn der try-Block geklappt hat
     }
 
     /**
      * Setzt den Schiedsrichter
+     * 
      * @param judge	gewünschte Judge-Instanz
      */
     public void setJudge(Judge judge) {
@@ -511,6 +511,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     
     /**
      * Lädt eine Welt aus einer Datei
+     * 
      * @param sourceFile	File-Objekt der Welt
      */
     public void openWorldFromFile(File sourceFile) {
@@ -524,6 +525,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 
     /**
      * Lädt eine Welt aus einem String
+     * 
      * @param parcoursAsXml	String mit den XML-Dater der Welt
      */
     public void openWorldFromXmlString(String parcoursAsXml) {
@@ -534,9 +536,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
         }
     }
 
-    /**
-     * Erzeugt eine zufällige Welt
-     */
+    /** Erzeugt eine zufällige Welt */
     public void openRandomWorld() {
         try {
             String p = ParcoursGenerator.generateParc();
@@ -548,9 +548,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
         }
     }
 
-    /**
-     * Init-Handler
-     */
+    /** Init-Handler */
     public void onApplicationInited() {
         view.onApplicationInited();
     }
@@ -558,7 +556,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
         
     /**
      * Setzt alle Bots im nächsten Sim-Schritt zurück.
-     * Dadurch, dass hier nur das Reset-Flag gesetzt wird, eruebriegt sich das 
+     * Dadurch, dass hier nur das Reset-Flag gesetzt wird, erübrigt sich das 
      * Synchronisieren der (Bot-)Threads; der Reset erfolgt einfach beim nächsten
      * Zeitschritt.
      */
@@ -568,10 +566,11 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
     
 	/**
 	 * Liefert ein Kommando an einen Bot aus.
-	 * Diese Routine kann dazu benutzt werden, um Bot-2-Bot-Kommunikation zu betreiben
-	 * Sender und Empfänger stehen in dem command drin 
-	 * @param command das zu übertragende Kommando
-	 * @throws ProtocolException Falls kein passender Empfänger gefunden wurde
+	 * Diese Routine kann dazu benutzt werden, um Bot-2-Bot-Kommunikation zu betreiben.
+	 * Sender und Empfänger stehen in dem command drin.
+	 *  
+	 * @param command	das zu übertragende Kommando
+	 * @throws ProtocolException	Falls kein passender Empfänger gefunden wurde
 	 */
 	public void deliverMessage(Command command) throws ProtocolException {
 		for (Bot b : bots) {
@@ -589,7 +588,7 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 			}
 		}	
 		if (!command.getTo().equals(Command.getBroadcastId())) {
-			// Es fuehlt sich wohl kein Bot aus der Liste zuständig ==> Fehler 
+			// Es fühlt sich wohl kein Bot aus der Liste zuständig => Fehler 
 			throw new ProtocolException("Nachricht an Empfänger "+command.getTo()+" nicht zustellbar. " +
 					"Kein Bot mit passender Id angemeldet");
 		}
@@ -597,7 +596,8 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 	
 	/**
 	 * Testet, ob bereits ein Bot diese Id hat
-	 * @param id zu testende Id
+	 * 
+	 * @param id	zu testende Id
 	 * @return True, wenn noch kein Bot diese Id nutzt 
 	 */
 	public boolean isIdFree(BotID id){
@@ -611,13 +611,14 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 		return true;
 	}
 	
-	/** Offset für die Adressvergabe, damit wir nicht jedesmal mit den schon vergebene2n Adressen beginnen */
+	/** Offset für die Adressvergabe, damit wir nicht jedesmal mit den schon vergebenen Adressen beginnen */
 	private int poolOffset = 0;
 	
 	/**
 	 * Liefert eine Id aus dem Adresspoll zurück
+	 * 
 	 * @return Die neue Id
-	 * @throws ProtocolException Wenn keine Adresse mehr frei
+	 * @throws ProtocolException	Wenn keine Adresse mehr frei
 	 */
 	public BotID generateBotId() throws ProtocolException{
 		byte poolSize= (byte)64;
@@ -637,11 +638,12 @@ implements Controller, BotBarrier, Runnable, BotReceiver {
 	
 	/**
 	 * Exportiert die aktuelle Welt in eine Bot-Map-Datei
-	 * @param bot Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird 
-	 * @param free Wert, mit dem freie Felder eingetragen werden (z.B. 100)
-	 * @param occupied Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
-	 * @throws IOException falls Fehler beim Schreiben der Datei
-	 * @throws MapException falls keine Daten in der Map
+	 * 
+	 * @param bot		Bot-Nr. dessen Startfeld als Koordinatenursprung der Map benutzt wird 
+	 * @param free		Wert mit dem freie Felder eingetragen werden (z.B. 100)
+	 * @param occupied	Wert mit dem Hindernisse eingetragen werden (z.B. -100)
+	 * @throws IOException	falls Fehler beim Schreiben der Datei
+	 * @throws MapException	falls keine Daten in der Map
 	 */
 	public void worldToMap(int bot, int free, int occupied) throws IOException, MapException {
 		this.world.toMap(bot, free, occupied);

--- a/ctSim/controller/InitializingPicoContainer.java
+++ b/ctSim/controller/InitializingPicoContainer.java
@@ -26,22 +26,19 @@ import org.picocontainer.Parameter;
 import org.picocontainer.PicoContainer;
 import org.picocontainer.defaults.DefaultPicoContainer;
 
-/**
- * Initialisierter Pico-Container 
- */
+/** Initialisierter Pico-Container */
 public class InitializingPicoContainer extends DefaultPicoContainer {
     /** UID */
 	private static final long serialVersionUID = - 6940983694133437239L;
 
-    /**
-     * Initialisierter Pico-Container 
-     */
+    /** Initialisierter Pico-Container */
     public InitializingPicoContainer() {
     	super();
     }
 
     /**
      * Initialisierter Pico-Container 
+     * 
      * @param parent 
      */
 	public InitializingPicoContainer(PicoContainer parent) {
@@ -50,6 +47,7 @@ public class InitializingPicoContainer extends DefaultPicoContainer {
 
 	/**
 	 * Getter
+	 * 
 	 * @param <T>
 	 * @param componentKey
 	 * @return T
@@ -60,6 +58,7 @@ public class InitializingPicoContainer extends DefaultPicoContainer {
 
 	/**
 	 * Klasse initialisiert?
+	 * 
 	 * @param classToInitialize Klasse
 	 */
 	private void ensureInitialized(Class<?> classToInitialize) {

--- a/ctSim/controller/Main.java
+++ b/ctSim/controller/Main.java
@@ -47,8 +47,7 @@ import ctSim.view.gui.SplashWindow;
  * ist der Aufruf der {@link #main(String[])}-Methode dieser Klasse.
  * </p>
  * <p>
- * Inhaltlich befasst sich die Klasse mit grundlegenden
- * Initialisierungs-Geschichten.
+ * Inhaltlich befasst sich die Klasse mit grundlegenden Initialisierungs-Geschichten.
  * </p>
  */
 public class Main {
@@ -79,7 +78,7 @@ public class Main {
 	 * Haupt-Einsprungpunkt in den ctSim. Das hier starten, um den ctSim zu
 	 * starten.
 	 *
-	 * @param args Als Kommandozeilenargumente sind momentan zulässig:
+	 * @param args	Als Kommandozeilenargumente sind momentan zulässig:
 	 * <ul>
 	 * <li>{@code -conf pfad/zur/konfigdatei.xml}: Andere Konfigurationsdatei
 	 * als die standardmäßige config/ct-sim.xml verwenden</li>
@@ -131,7 +130,7 @@ public class Main {
 	/**
 	 * Siehe {@link #main(String...)}.
 	 * 
-	 * @param args Command-Line-Argumente
+	 * @param args	Command-Line-Argumente
 	 */
 	private static void handleCommandLineArgs(String[] args) {
 		for (int i = 0; i < args.length; i++) {
@@ -152,7 +151,8 @@ public class Main {
 
 	/**
 	 * Initialisiert den Logger
-	 * @return	Logger-Instanz
+	 * 
+	 * @return Logger-Instanz
 	 */
 	public static FmtLogger initLogging() {
 		try {
@@ -172,9 +172,7 @@ public class Main {
 		return rv;
     }
 
-	/**
-	 * Lädt die Konfiguration
-	 */
+	/** Lädt die Konfiguration */
 	private static void loadConfig() {
 		try {
 			Config.loadConfigFile(DEFAULT_CONFIGFILE);
@@ -193,9 +191,7 @@ public class Main {
 		}
 	}
 
-	/**
-	 * Initialisierung von View und Controller
-	 */
+	/** Initialisierung von View und Controller */
 	private static void setupViewAndController() {
 		Controller c = dependencies.get(Controller.class);
 

--- a/ctSim/model/BPS.java
+++ b/ctSim/model/BPS.java
@@ -24,6 +24,7 @@ import javax.vecmath.Point3d;
 
 /**
  * Repräsentiert das Bot Positioning System (BPS) im Simulator
+ * 
  * @author Timo Sandmann
  */
 public class BPS {

--- a/ctSim/model/BPS.java
+++ b/ctSim/model/BPS.java
@@ -44,6 +44,7 @@ public class BPS {
 		
 		/**
 		 * Erzeugt eine neue Landmarke
+		 * 
 		 * @param parc Parcours, in dem die Landmarke steht
 		 * @param source Position der Landmarke, so wie PickInfo sie ermittelt hat [m]
 		 */
@@ -61,6 +62,7 @@ public class BPS {
 		
 		/**
 		 * Gibt die Position der Landmarke als String aus [BEACON_GRID_SIZE mm]
+		 * 
 		 * @see java.lang.Object#toString()
 		 */
 		@Override
@@ -71,6 +73,7 @@ public class BPS {
 		
 		/**
 		 * Gibt die Position der Landmarke als String aus [Parcours-Block-Koordinaten]
+		 * 
 		 * @return (X|Y) [Parcours-Block-Koordinaten]
 		 * @see #toString()
 		 */
@@ -80,9 +83,10 @@ public class BPS {
 		
 //		/**
 //		 * Prüft, ob die angegebene Parcours-Position für eine BPS-Landmarke gueltig ist
-//		 * @param parc Parcours, in dem die Landmarke steht
-//		 * @param x X-Koordinate [Parcours-Block]
-//		 * @param y Y-Koordinate [Parcours-Block]
+//		
+//		 * @param parc	Parcours, in dem die Landmarke steht
+//		 * @param x		X-Koordinate [Parcours-Block]
+//		 * @param y		Y-Koordinate [Parcours-Block]
 //		 * @return true, falls Landmarke an (x|y) möglich, sonst false
 //		 */
 //		public static boolean checkParcoursPosition(Parcours parc, int x, int y) {

--- a/ctSim/model/Command.java
+++ b/ctSim/model/Command.java
@@ -48,106 +48,88 @@ import ctSim.util.Misc;
 
 /**
  * <p>
- * Hauptteil des Protokolls zwischen c't-Sim und Bot-Steuercode (sog.
- * <em>c't-Bot-Protokoll</em>). Eingesetzt wird diese Klasse vorwiegend in
- * zwei Fällen:
+ * Hauptteil des Protokolls zwischen c't-Sim und Bot-Steuercode (sog. <em>c't-Bot-Protokoll</em>).
+ * Eingesetzt wird diese Klasse vorwiegend in zwei Fällen:
  * <ol>
- * <li>Ein realer (in Hardware existierender) Bot, der per USB oder TCP
- * verbunden ist, sendet laufend Messwerte der Sensoren und andere
- * Statusinformationen. 12 Byte auf dem Draht stellen die Messwerte eines
- * Sensorpaars dar, z.B. linker und rechter Distanzsensor; die Aufgabe dieser
- * Klasse ist das Lesen und Repräsentieren dieser 12 Byte innerhalb des
- * Sim.</li>
- * <li>Ein simulierter Bot (Bot-Steuercode, auf einem PC läuft) bekommt
- * über seine TCP-Verbindung vom Sim Sensorwerte gefüttert. Der Sim
- * speichert die Werte in einem Command-Objekt, das er anschließend ins
- * TCP schreibt.</li>
+ * <li>Ein realer (in Hardware existierender) Bot, der per USB oder TCP verbunden ist, sendet laufend
+ * Messwerte der Sensoren und andere Statusinformationen. 12 Byte auf dem Draht stellen die Messwerte
+ * eines Sensorpaars dar, z.B. linker und rechter Distanzsensor; die Aufgabe dieser Klasse ist das
+ * Lesen und Repräsentieren dieser 12 Byte innerhalb des Sim.</li>
+ * <li>Ein simulierter Bot (Bot-Steuercode, auf einem PC läuft) bekommt über seine TCP-Verbindung
+ * vom Sim Sensorwerte gefüttert. Der Sim speichert die Werte in einem Command-Objekt, das er
+ * anschließend ins TCP schreibt.</li>
  * </ol>
  * </p>
  * <p>
  * Diese Klasse behandelt das Dekodieren eines Commands aus einem Haufen Bytes
- * (siehe {@linkplain #Command(Connection) Konstruktor}) und das Enkodieren
- * eines Commands (siehe {@link #getCommandBytes()}). Verwendet und
- * interpretiert werden die Commands in den Bot-Komponenten. Die betreffenden
- * Komponenten stehen in der {@linkplain Code Liste der Command-Codes}.
+ * (siehe {@linkplain #Command(Connection) Konstruktor}) und das Enkodieren eines Commands
+ * (siehe {@link #getCommandBytes()}). Verwendet und interpretiert werden die Commands in den
+ * Bot-Komponenten. Die betreffenden Komponenten stehen in der
+ * {@linkplain Code Liste der Command-Codes}.
  * </p>
  * <p>
- * <strong>Beispiel</strong> eines Command:
+ * <strong>Beispiel</strong> eines Commands:
  *
  * <pre>
- * Byte#         Wert            Bedeutung
+ * Byte#		Wert			Bedeutung
  * im TCP
- *   0           '&gt;' (Ascii 62)  Startcode, markiert Beginn des Command, ist
- *                               immer '&gt;'
- *   1           'H' (Ascii 72)  Command-Code, hier der für die
- *                               Helligkeitssensoren
- *   2 Bit 0     0               Richtungsangabe, 0 = Anfrage, 1 = Antwort. Ist
- *                               historisch und steht immer auf 0.
- *   2 Bits 1-7  'N' (Ascii 78)  Sub-Command-Code: Nur von einigen Command-Codes
- *                               verwendet, ist normalerweise N ("normal")
- *   3           0               Länge der Nutzlast in Byte, hier: keine
- *                               Nutzlast
- *   4           42              Datenfeld "dataL" LSB: niederwertiges Byte des
- *                               Messwerts des linken Helligkeitssensors
- *   5           1               dataL MSB: höherwertiges Byte des Messwerts
- *   6           37              dataR LSB: niederwertiges Byte rechter
- *                               Helligkeitssensor
- *   7           0               dataR MSB: zugehöriges höherwertiges Byte
- *   8           61              Sequenznummer LSB, bei aufeinanderfolgenden
- *                               Commands erhöht sich die Sequenznummer immer
- *                               um eins
- *   9          0               Absender-Id des Paketes
- *  10          0               Empänger-Id des Paketes
- *  11           '&lt;' (Ascii 60)  CRC-Code, markiert Command-Ende, ist immer '&lt;'
- *                               (Name "CRC" irreführend)
- *  12 und folgende              Nutzlast falls vorhanden. Wird z.B. verwendet,
- *                               wenn der Bot den Inhalt des LCD überträgt oder
- *                               die Bilddaten, was der Maussensor sieht
+ * 	0			'>' (Ascii 62)	Startcode, markiert Beginn des Command, ist immer '>'
+ * 	1			'H' (Ascii 72)	Command-Code, hier der für die Helligkeitssensoren
+ * 	2 Bit 0	0					Richtungsangabe, 0 = Anfrage, 1 = Antwort.
+ * 								Ist historisch und steht immer auf 0.
+ * 	2 Bits 1-7	'N' (Ascii 78)  Sub-Command-Code: Nur von einigen Command-Codes verwendet,
+ * 								ist normalerweise N ("normal").
+ * 	3			0				Länge der Nutzlast in Byte, hier: keine Nutzlast
+ * 	4			42				Datenfeld "dataL" LSB: niederwertiges Byte des
+ * 								Messwerts des linken Helligkeitssensors
+ * 	5			1				dataL MSB: höherwertiges Byte des Messwerts
+ * 	6			37				dataR LSB: niederwertiges Byte rechter Helligkeitssensor
+ * 	7			0				dataR MSB: zugehöriges höherwertiges Byte
+ * 	8			61				Sequenznummer LSB, bei aufeinanderfolgenden Commands
+ * 								erhöht sich die Sequenznummer immer um eins
+ * 	9			0               Absender-Id des Paketes
+ * 	10          0               Empänger-Id des Paketes
+ *  11			'<' (Ascii 60)	CRC-Code, markiert Command-Ende, ist immer '<' (Name "CRC" irreführend)
+ * 	12 und folgende				Nutzlast falls vorhanden. Wird z.B. verwendet, wenn der Bot den Inhalt
+ * 								des LCD überträgt oder die Bilddaten, von dem was der Maussensor sieht
  * </pre>
  *
  * </p>
  * <p>
- * Für einen <strong>realen Bot</strong> besteht das Protokoll aus
- * folgenden Regeln:
+ * Für einen <strong>realen Bot</strong> besteht das Protokoll aus folgenden Regeln:
  * <ul>
  * <li>Der Bot-Steuercode sendet laufend Commands mit Sensor-Messwerten und
  * anderen Statusinformationen, die der Sim auswertet und dem Benutzer anzeigt.
- * Welche einzelnen Commands behandelt werden, und wie sie im Detail
- * interpretiert werden, ist Sache der Bot-Komponenten wie in der
- * {@linkplain Code Command-Code-Liste} beschrieben. </li>
- * <li>Beim Start des Sim überträgt er ein Command mit dem
- * Command-Code {@link Command.Code#WELCOME WELCOME}, das einen Handshake anfordert.
+ * Welche einzelnen Commands behandelt werden, und wie sie im Detail interpretiert
+ * werden, ist Sache der Bot-Komponenten wie in der {@linkplain Code Command-Code-Liste}
+ * beschrieben. </li>
+ * <li>Beim Start des Sim überträgt er ein Command mit dem Command-Code
+ * {@link Command.Code#WELCOME WELCOME}, das einen Handshake anfordert.
  * Der Bot antwortet mit einem Command, das ihn als realen Bot ausweist
- * (Command-Code WELCOME, Sub-Command-Code
- * {@link Command.SubCode#WELCOME_REAL WELCOME_REAL}). Falls der Bot schon läuft,
- * wenn der Sim die Verbindung aufbaut, sendet der Sim trotzdem ein
- * {@code WELCOME}; bei USB-Verbindungen (COM-Verbindungen) schickt der Sim
- * kein {@code WELCOME}, da von vornherein klar ist, dass es ein Real-Bot sein
- * muss. Aus Sicht des Bot kann ein Handshake also jederzeit kommen oder
- * überhaupt nie.</li>
- * <li>Jederzeit während der Verbindung kann der Sim ein Command senden,
- * das das Bild anfordert, das der Maussensor auf der Botunterseite sieht
- * (Command-Code {@link Command.Code#SENS_MOUSE_PICTURE SENS_MOUSE_PICTURE}). Der Bot
- * beantwortet das mit einer Serie von Commands mit dem Aufbau, der in
- * {@link MousePictureComponent} beschrieben ist</li>
- * <li>Jederzeit während der Verbindung kann der Sim ein Command senden,
- * das einen Befehl der RC5-Fernbedienung repräsentiert (Command-Code
- * {@link Command.Code#SENS_RC5 SENS_RC5})</li>
+ * (Command-Code WELCOME, Sub-Command-Code {@link Command.SubCode#WELCOME_REAL WELCOME_REAL}) 
+ * Falls der Bot schon läuft, wenn der Sim die Verbindung aufbaut, sendet der Sim trotzdem ein
+ * {@code WELCOME}; bei USB-Verbindungen (COM-Verbindungen) schickt der Sim kein {@code WELCOME},
+ * da von vornherein klar ist, dass es ein Real-Bot sein muss.
+ * Aus Sicht des Bot kann ein Handshake also jederzeit kommen oder überhaupt nie.</li>
+ * <li>Jederzeit während der Verbindung kann der Sim ein Command senden, das das Bild anfordert,
+ * das der Maussensor auf der Botunterseite sieht (Command-Code
+ * {@link Command.Code#SENS_MOUSE_PICTURE SENS_MOUSE_PICTURE}).
+ * Der Bot beantwortet das mit einer Serie von Commands mit dem Aufbau, der in
+ * {@link MousePictureComponent} beschrieben ist.</li>
+ * <li>Jederzeit während der Verbindung kann der Sim ein Command senden, das einen Befehl der
+ * RC5-Fernbedienung repräsentiert (Command-Code {@link Command.Code#SENS_RC5 SENS_RC5})</li>
  * </ul>
  * </p>
  * <p>
  * Für einen <strong>simulierten Bot</strong> ist das Protokoll:
  * <ul>
- * <li>Der Sim lauscht auf dem TCP-Port, der in der Konfigdatei angegeben ist
- * (Parameter "botport").</li>
- * <li>Bot-Steuercode verbindet sich mit dem TCP-Port. Der Sim sendet ein
- * Command mit dem {@link Command.Code#WELCOME WELCOME}, das einen Handshake anfordert.
- * Der Bot antwortet mit einem Command, das ihn als simulierten Bot ausweist
- * (Command-Code WELCOME, Sub-Command-Code
- * {@link Command.SubCode#WELCOME_SIM WELCOME_SIM}).</li>
- * <li>Der Sim sendet einen Block von Commands, die Sensorwerte beschreiben. Er
- * ist abgeschlossen mit einem Command, was den Command-Code
- * {@link Command.Code#DONE DONE} hat. Beispiel:
+ * <li>Der Sim lauscht auf dem TCP-Port, der in der Konfigdatei angegeben ist (Parameter "botport").</li>
+ * <li>Bot-Steuercode verbindet sich mit dem TCP-Port. Der Sim sendet ein Command mit dem
+ * {@link Command.Code#WELCOME WELCOME}, das einen Handshake anfordert.
+ * Der Bot antwortet mit einem Command, das ihn als simulierten Bot ausweist (Command-Code WELCOME,
+ * Sub-Command-Code {@link Command.SubCode#WELCOME_SIM WELCOME_SIM}).</li>
+ * <li>Der Sim sendet einen Block von Commands, die Sensorwerte beschreiben. Er ist abgeschlossen mit
+ * einem Command, was den Command-Code {@link Command.Code#DONE DONE} hat. Beispiel:
  *
  * <pre>
  * Richtung  Command-Code         dataL dataR
@@ -164,16 +146,14 @@ import ctSim.util.Misc;
  * Sim->Bot: SENS_ENC             L   0 R   0 Payload=''
  * Sim->Bot: DONE                 L  30 R   0 Payload=''</pre>
  *
- * Wenn ein Bot andere Sensoren hätte als der normale c't-Bot, sähe
- * die Liste anders aus. Manche Sensoren senden nur, wenn sie etwas zu senden
- * haben (Beispiel für dieses Verhalten: SENS_MOUSE_PICTURE, also die
- * {@link MousePictureComponent}). Das DONE-Command enthält die aktuelle
- * Simulatorzeit in Millisekunden, falls der Bot zeitabhängige Sachen
- * rechnen will. </li>
- * <li>Der Bot berechnet auf Basis der simulierten Sensorwerte seine
- * nächsten Aktionen. Dann sendet er einen Block von Commands mit
- * Aktuatorwerten. Er ist abgeschlossen mit einem Command, was den Command-Code
- * {@link Command.Code#DONE DONE} hat. Beispiel:
+ * Wenn ein Bot andere Sensoren hätte als der normale c't-Bot, sähe die Liste anders aus.
+ * Manche Sensoren senden nur, wenn sie etwas zu senden haben (Beispiel für dieses Verhalten:
+ * SENS_MOUSE_PICTURE, also die {@link MousePictureComponent}).
+ * Das DONE-Command enthält die aktuelle Simulatorzeit in Millisekunden, falls der Bot
+ * zeitabhängige Sachen rechnen will. </li>
+ * <li>Der Bot berechnet auf Basis der simulierten Sensorwerte seine nächsten Aktionen.
+ * Dann sendet er einen Block von Commands mit Aktuatorwerten. Er ist abgeschlossen mit einem Command,
+ * was den Command-Code {@link Command.Code#DONE DONE} hat. Beispiel:
  *
  * <pre>
  * Richtung  CmdCode/SubCmdCode   dataL dataR
@@ -190,25 +170,22 @@ import ctSim.util.Misc;
  * Bot->Sim: ACT_LCD/LCD_DATA     L   0 R   0 Payload='I=1005 M=00000 00000'
  * Bot->Sim: DONE                 L  30 R   0 Payload=''</pre>
  *
- * Das DONE-Command enthält zur Bestätigung die Simulatorzeit, die vom
- * c't-Sim zuletzt empfangen wurde. </li>
+ * Das DONE-Command enthält zur Bestätigung die Simulatorzeit, die vom c't-Sim zuletzt empfangen wurde.</li>
  * </li>
- * Falls der Sim vom Benutzer pausiert wird, kann beliebig viel Armbanduhrenzeit
- * zwischen einem Block und dem nächsten liegen. Die Simulatorzeit
- * (DONE-Command) wird davon jedoch nicht beeinflusst. Bot-Steuercode sollte
- * sich also auf die Simulatorzeit verlassen, nicht auf Armbanduhrenzeit.
+ * Falls der Sim vom Benutzer pausiert wird, kann beliebig viel Armbanduhrenzeit zwischen einem Block
+ * und dem nächsten liegen. Die Simulatorzeit (DONE-Command) wird davon jedoch nicht beeinflusst.
+ * Bot-Steuercode sollte sich also auf die Simulatorzeit verlassen, nicht auf Armbanduhrenzeit.
  * <li>
  * </ul>
  * </p>
  * <p>
- * Die Endianness auf dem Draht bei uns ist <a
- * href="http://de.wikipedia.org/wiki/Little_endian">Little-Endian</a>. Java
- * verwendet intern Big-Endian. Die Konvertierung erfolgt zu Fuß in dieser
- * Klasse.
+ * Die Endianness auf dem Draht bei uns ist
+ * <a href="http://de.wikipedia.org/wiki/Little_endian">Little-Endian</a>.
+ * Java verwendet intern Big-Endian. Die Konvertierung erfolgt zu Fuß in dieser Klasse.
  * </p>
  *
  * @author Benjamin Benz (bbe@heise.de)
- * @author Hendrik Krauß &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * @author Hendrik Krauß (hkr@heise.de)
  */
 public class Command {
 	/** Logger */
@@ -226,7 +203,7 @@ public class Command {
 	/** Direction Anfrage. Commands haben immer das hier gesetzt. */
 	public static final int DIR_REQUEST = 0;
 
-	/** Direction Antwort. Nicht verwendet. */
+	/** Direction Antwort (wird nicht verwendet) */
 	public static final int DIR_ANSWER = 1;
 	
 	/** Maximale Anzahl an Bytes, die als Payload mitgeschickt werden können */
@@ -238,16 +215,14 @@ public class Command {
 	/** Broadcast Adresse */
 	private static final BotID BROADCAST_ID = new BotID(0xFF);
 	
-	/**
-	 * Interface für Codes
-	 */
+	/** Interface für Codes */
 	public static interface BotCodes {
 		/**
 		 * SubCodes werden erzeugt mit dieser Methode (und nur mit dieser).
 		 * SubCodes sind mit dem Code-Enum verkoppelt, da vom Code abhängt,
-		 * ob z.B. ein "R" auf dem Draht für den SubCode
-		 * WELCOME_REAL oder für RIGHT steht.
-		 * @param b Int
+		 * ob z.B. ein "R" auf dem Draht für den SubCode WELCOME_REAL oder für RIGHT steht.
+		 * 
+		 * @param b	Int
 		 * @return SubCude
 		 * @throws ProtocolException 
 		 */
@@ -261,24 +236,24 @@ public class Command {
 		
 		/**
 		 * Kommando-Code als String
+		 * 
 		 * @return Code des Kommandos
 		 */
 		public String toString();
 	}
 	
-	/**
-	 * Interface für Subcodes 
-	 */
+	/** Interface für Subcodes */
 	public static interface BotSubCodes {
 		/**
 		 * @return Liefert das Byte, wie dieser SubCode auf dem Draht (im TCP oder USB)
-		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher
-		 * wird ein 7 Bit langer unsigned Int zurückgegeben.
+		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher wird ein
+		 * 7 Bit langer unsigned Int zurückgegeben.
 		 */
 		public byte toUint7();
 		
 		/**
 		 * Subkommando-Code als String
+		 * 
 		 * @return Code des Subkommandos
 		 */
 		public String toString();
@@ -330,8 +305,7 @@ public class Command {
 		private byte codeOnTheWire;
 		
 		/**
-		 * @param code	Code des Kommandos als byte
-		 * (wird nicht weiter geprüft)
+		 * @param code	Code des Kommandos als byte (wird nicht weiter geprüft)
 		 */
 		public Bot2BotCode(byte code) {
 			codeOnTheWire = code;
@@ -339,7 +313,8 @@ public class Command {
 		
 		/**
 		 * SubCodes werden erzeugt mit dieser Methode (und nur mit dieser).
-		 * @param b Subcode als int
+		 * 
+		 * @param b	Subcode als int
 		 * @return Bot2BotSubCode-Instanz
 		 * @throws ProtocolException 
 		 */
@@ -349,8 +324,8 @@ public class Command {
 		
 		/**
 		 * @return Liefert das Byte, wie dieser SubCode auf dem Draht (im TCP oder USB)
-		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher
-		 * wird ein 7 Bit langer unsigned Int zurückgegeben.
+		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher wird ein
+		 * 7 Bit langer unsigned Int zurückgegeben.
 		 */
 		public byte toUint7() { 
 			return codeOnTheWire; 
@@ -369,8 +344,8 @@ public class Command {
 	// Enum Command-Code
 	
 	/**
-	 * Ein Command-Code kann einen der Werte in diesem Enum haben. Der
-	 * Command-Code gibt den Typ des Commands an.
+	 * Ein Command-Code kann einen der Werte in diesem Enum haben.
+	 * Der Command-Code gibt den Typ des Commands an.
 	 */
 	public static enum Code implements BotCodes {
 		/** Zum Hallo-Sagen (Handshake); siehe {@link Command}. */
@@ -460,34 +435,29 @@ public class Command {
 			SubCode.REMOTE_CALL_ENTRY, SubCode.REMOTE_CALL_ORDER,
 			SubCode.REMOTE_CALL_DONE, SubCode.REMOTE_CALL_ABORT),
 			
-		/**
-		 * Map-Übertragung 
-		 */
+		/** Map-Übertragung */
 		MAP('Q', SubCode.MAP_DATA_1, SubCode.MAP_DATA_2, SubCode.MAP_DATA_3,
 				SubCode.MAP_DATA_4, SubCode.MAP_REQUEST, SubCode.MAP_LINE,
 				SubCode.MAP_CIRCLE,	SubCode.MAP_CLEAR_LINES, 
 				SubCode.MAP_CLEAR_CIRCLES, SubCode.MAP_REQUEST),
 
-		/**
-		 * Kommando zum Herunterfahren
-		 */
+		/** Kommando zum Herunterfahren */
 		SHUTDOWN('q', SubCode.NORM),		
 				
-		/**
-		 * Programmdaten (Basic oder ABL)
-		 */
+		/** Programmdaten (Basic oder ABL) */
 		PROGRAM('p', SubCode.PROGRAM_PREPARE, SubCode.PROGRAM_DATA, SubCode.PROGRAM_START, SubCode.PROGRAM_STOP);
 		
 		/** Code auf der Leitung */
 		private final byte onTheWire;
-		/** gueltige SubCodes */
+		/** gültige SubCodes */
 		private final SubCode[] validSubCodes;
 
 		/**
 		 * Konschtruktor; nicht aufrufbar; stattdessen {@link #fromByte(int)}
 		 * verwenden. Setzt die zugelassenen SubCodes für diese
 		 * Code-Instanz auf NORM und nichts sonst.
-		 * @param c Code
+		 * 
+		 * @param c	Code
 		 */
 		private Code(char c) {
 			this(c, SubCode.NORM);
@@ -498,7 +468,8 @@ public class Command {
 		 * Die Code-Instanz kennt ihre möglichen SubCodes, da etwa ein
 		 * SubCode "L" nach Code ACT_LCD was anderes heißt als
 		 * nach Code REMOTE_CALL. Das muss unterschieden werden können.
-		 * @param c Subcode
+		 * 
+		 * @param c	Subcode
 		 * @param validSubCodes Subcode-Instanz
 		 */
 		private Code(char c, SubCode... validSubCodes) {
@@ -510,14 +481,15 @@ public class Command {
 
 		/**
 		 * @return Liefert das Byte, wie dieser SubCode auf dem Draht (im TCP oder USB)
-		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher
-		 * wird ein 7 Bit langer unsigned Int zurückgegeben.
+		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher wird ein
+		 * 7 Bit langer unsigned Int zurückgegeben.
 		 */
 		public byte toUint7() { return onTheWire; }
 
 		/**
 		 * Erzeugt eine SubCode-Instanz. Akzeptiert ints aus Toleranz.
-		 * @param b Byte
+		 * 
+		 * @param b	Byte
 		 * @return SubCode
 		 *
 		 * @throws ProtocolException falls der Ascii-Wert von {@code b} keiner
@@ -535,9 +507,9 @@ public class Command {
 		/**
 		 * SubCodes werden erzeugt mit dieser Methode (und nur mit dieser).
 		 * SubCodes sind mit dem Code-Enum verkoppelt, da vom Code abhängt,
-		 * ob z.B. ein "R" auf dem Draht für den SubCode
-		 * WELCOME_REAL oder für RIGHT steht.
-		 * @param b Int
+		 * ob z.B. ein "R" auf dem Draht für den SubCode WELCOME_REAL oder für RIGHT steht.
+		 * 
+		 * @param b	Int
 		 * @return SubCude
 		 * @throws ProtocolException 
 		 */
@@ -552,12 +524,11 @@ public class Command {
 		}
 
 		/**
-		 * @param sc Subcode
+		 * @param sc	Subcode
 		 * @throws ProtocolException
 		 */
 		public void assertSubCodeValid(SubCode sc) throws ProtocolException {
-			// Wenn SubCode ungueltig, explodiert der folgende Aufruf mit einer
-			// ProtoExcp
+			// Wenn SubCode ungültig, explodiert der folgende Aufruf mit einer ProtoExcp
 			getSubCode(sc.toUint7());
 		}
 	}
@@ -583,16 +554,14 @@ public class Command {
 		LCD_CURSOR('C'),
 
 		/**
-		 * Subkommando für Handshake mit "Real-Bot", siehe
-		 * {@linkplain Command}.
+		 * Subkommando für Handshake mit "Real-Bot", siehe {@linkplain Command}.
 		 *
 		 * @see RealCtBot
 		 */
 		WELCOME_REAL('R'),
 
 		/**
-		 * Subkommando für Handshake mit "Sim-Bot", siehe
-		 * {@linkplain Command}.
+		 * Subkommando für Handshake mit "Sim-Bot", siehe {@linkplain Command}.
 		 *
 		 * @see SimulatedBot
 		 * @see CtBotSimTcp
@@ -617,8 +586,7 @@ public class Command {
 
 		/**
 		 * Signalisiert dem Sim, dass ein Remote-Call abgeschlossen wurde.
-		 * Ergebnis des Remote-Call steht in dataL (1 = geklappt, 0 = in die
-		 * Hose gegangen)
+		 * Ergebnis des Remote-Call steht in dataL (1 = geklappt, 0 = fehlgeschlagen)
 		 */
 		REMOTE_CALL_DONE('D'),
 
@@ -666,7 +634,9 @@ public class Command {
 		/** Fordert die komplette Map an */
 		MAP_REQUEST('R'),
 		
-		/** Überträgt die ersten 128 Byte der Map-Daten eines Blocks (vier Kommandos für einen kompletten Block nötig) */
+		/** Überträgt die ersten 128 Byte der Map-Daten eines Blocks
+		 * (vier Kommandos für einen kompletten Block nötig)
+		 * */
 		MAP_DATA_1('D'),
 		
 		/** Map-Daten Teil 2 (Byte 128 bis 255) */
@@ -697,7 +667,8 @@ public class Command {
 		/**
 		 * Konschtruktor; nicht aufrufbar; stattdessen {@link Command.Code#getSubCode(int)}
 		 * verwenden.
-		 * @param c Subcode
+		 * 
+		 * @param c	Subcode
 		 */
 		private SubCode(char c) {
 			if (c > 127)
@@ -707,8 +678,8 @@ public class Command {
 
 		/**
 		 * @return Liefert das Byte, wie dieser SubCode auf dem Draht (im TCP oder USB)
-		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher
-		 * wird ein 7 Bit langer unsigned Int zurückgegeben.
+		 * dargestellt werden soll. Das erste Bit des Byte ist immer 0; daher wird ein
+		 * 7 Bit langer unsigned Int zurückgegeben.
 		 */
 		public byte toUint7() { 
 			return onTheWire; 
@@ -749,15 +720,15 @@ public class Command {
 	private final byte crc;
 
 	/**
-	 * Client-Code kann damit markieren, ob das Kommando verarbeitet ist oder
-	 * nicht. Gibt einen Getter und Setter dafür, sonst hat diese Klasse
-	 * damit nichts am Hut.
+	 * Client-Code kann damit markieren, ob das Kommando verarbeitet ist oder nicht.
+	 * Gibt einen Getter und Setter dafür, sonst hat diese Klasse damit nichts am Hut.
 	 */
 	private boolean hasBeenProcessed = false;
 
 	/** 
-	 * Erzeugt ein Kommando 
-	 * @param code des Kommandos 
+	 * Erzeugt ein Kommando
+	 * 
+	 * @param code	Code des Kommandos 
 	 */
 	public Command(Code code) {
 		this.commandCode = code;
@@ -770,9 +741,10 @@ public class Command {
 	/**
 	 * Wie {@link #Command(Connection, boolean)} mit
 	 * {@code suppressSyncWarnings == false} (dem Normalwert).
-	 * @param con Connection für das Kommando
-	 * @throws IOException 
-	 * @throws ProtocolException 
+	 * 
+	 * @param con	Connection für das Kommando
+	 * @throws IOException
+	 * @throws ProtocolException
 	 */
 	public Command(Connection con) throws IOException, ProtocolException {
 		this(con, false);
@@ -789,18 +761,18 @@ public class Command {
 	 * Normalbetrieb kommt sie nicht vor, da auf einen CRC-Code ohne weiteren
 	 * Zwischenkram der Startcode des nächsten Kommandos folgen muss.
 	 * </p>
-	 * @param con Connection für das Kommando
+	 * @param con	Connection für das Kommando
 	 *
-	 * @param suppressSyncWarnings Unterdrückt die "Synchronisierung
-	 * verloren"-Warnung (s.o.), d.h. gibt sie auf Log-Level {@code FINE}
-	 * aus statt auf {@code WARNING}. Das ist sinnvoll für den Handshake
-	 * mit einem realen Bot: Wenn der Bot schon Kommandos sendet, wenn der Sim
-	 * sich mit ihm verbindet, dann ist es leicht möglich, dass der Sim
-	 * mitten in einem Kommando dazukommt. In diesem Fall verwirrt die Meldung
-	 * mehr, als sie hilft.
-	 * @throws IOException Bei E/A-Fehler während dem Lesen
-	 * @throws ProtocolException Falls ein ungültiger CRC empfangen wird
-	 * oder die Direction nicht {@link #DIR_REQUEST} ist.
+	 * @param suppressSyncWarnings
+	 * Unterdrückt die "Synchronisierung verloren"-Warnung (s.o.), d.h. gibt sie auf Log-Level
+	 * {@code FINE} aus statt auf {@code WARNING}. Das ist sinnvoll für den Handshake mit einem
+	 * realen Bot: Wenn der Bot schon Kommandos sendet, wenn der Sim sich mit ihm verbindet,
+	 * dann ist es leicht möglich, dass der Sim mitten in einem Kommando dazukommt. In diesem Fall
+	 * verwirrt die Meldung mehr, als sie hilft.
+	 * 
+	 * @throws IOException	Bei E/A-Fehler während dem Lesen
+	 * @throws ProtocolException
+	 * Falls ein ungültiger CRC empfangen wird oder die Direction nicht {@link #DIR_REQUEST} ist.
 	 */
 	public Command(Connection con, boolean suppressSyncWarnings)
 	throws IOException, ProtocolException {
@@ -827,7 +799,7 @@ public class Command {
 		}
 
 		// Rest des Kommandos
-		b = new byte[COMMAND_SIZE - 1]; // -1: Startcode haben wir schon
+		b = new byte[COMMAND_SIZE - 1];	// -1: Startcode haben wir schon
 		con.read(b);
 
 		byte i =0;
@@ -852,11 +824,11 @@ public class Command {
 		i+=2;
 		
 		seq=b[i++];	// neue Version mit Adressen und kurzer seq
-		// alte version seq   = (short) ( ( b[ i+1 ] & 0xff ) << 8 | ( b[ i ] & 0xff ) );	i++;
+//		seq = (short) ( ( b[ i+1 ] & 0xff ) << 8 | ( b[ i ] & 0xff ) ); i++; // alte Version
 				
 		
 		from.set(b[i++]);	// neue Version mit Adressen
-		to.set(b[i++]); // neue Version mit Adressen		
+		to.set(b[i++]);	// neue Version mit Adressen		
 		
 		if (to.equals(Command.getSimId())) {
 			commandCode = Code.fromByte(code);
@@ -883,6 +855,7 @@ public class Command {
 	/**
 	 * {@code true}, falls dieses Kommando den Command-Code
 	 * {@code someCommandCode} hat. Andernfalls {@code false}.
+	 * 
 	 * @param someCommandCode 
 	 * @return true/false
 	 */
@@ -893,6 +866,7 @@ public class Command {
 	/**
 	 * {@code true}, falls dieses Kommando den Sub-Command-Code
 	 * {@code subCommandCode} hat. Andernfalls {@code false}.
+	 * 
 	 * @param subCode 
 	 * @return true/false
 	 */
@@ -922,7 +896,7 @@ public class Command {
 		data[i++] = (byte)(dataR & 255);
 		data[i++] = (byte)(dataR >> 8);
 		data[i++] = (byte)(seq & 255);
-	//	data[i++] = (byte)(seq >> 8); // alte Version mit 16-Bit seq
+//		data[i++] = (byte)(seq >> 8);	// alte Version mit 16-Bit seq
 		
 		// neue Version mit Sender-Ids
 		data[i++] = from.byteValue();
@@ -938,7 +912,8 @@ public class Command {
 	/**
 	 * Hilfsmethode: Liefert Char und Ascii-Code zu einem {@code char} oder nur
 	 * den Ascii-Code, falls es non-printable ist.
-	 * @param aChar Der char
+	 * 
+	 * @param aChar	Der char
 	 * @return Char- und ASCII-Code
 	 */
 	static String formatChar(int aChar) {
@@ -977,7 +952,8 @@ public class Command {
 	}
 
 	/** 
-	 * Liefert eine kompakte Stringrepräsentation des Command (1 Zeile) 
+	 * Liefert eine kompakte Stringrepräsentation des Command (1 Zeile)
+	 * 
 	 * @return String 
 	 */
 	public String toCompactString() {
@@ -990,7 +966,8 @@ public class Command {
 	}
 
 	/** 
-	 * Gibt die angehängten Nutzdaten zurück 
+	 * Gibt die angehängten Nutzdaten zurück
+	 * 
 	 * @return Payload als byte-Array 
 	 */
 	public byte[] getPayload() { return payload; }
@@ -998,6 +975,7 @@ public class Command {
 	/**
 	 * Gibt die Nutzdaten als String zurück, unter Verwendung des
 	 * Standard-Charset – siehe {@link String#String(byte[])}.
+	 * 
 	 * @return Payload als String
 	 */
 	public String getPayloadAsString() {
@@ -1008,7 +986,8 @@ public class Command {
 	 * Ersetzt jedes Steuerzeichen (Ascii 0 bis inkl. Ascii 31) durch einen
 	 * Punkt (.), so dass man den String gefahrlos ausgeben kann.
 	 * Ein Linefeed (0x0A) bleibt aber erhalten. 
-	 * @param s Input-String
+	 * 
+	 * @param s	Input-String
 	 * @return Output-String
 	 */
 	public static String replaceCtrlChars(String s) {
@@ -1022,10 +1001,11 @@ public class Command {
 	}
 
 	/**
-	 * Wenn man den Payload in einer Zeile anzeigen will: Ersetzt Newlines, so
-	 * dass der Benutzer keinen Zeilenwechsel sieht, sondern die zwei Zeichen
+	 * Wenn man den Payload in einer Zeile anzeigen will: Ersetzt Newlines,
+	 * sodass der Benutzer keinen Zeilenwechsel sieht, sondern die zwei Zeichen
 	 * "\n".
-	 * @param s Input-String
+	 * 
+	 * @param s	Input-String
 	 * @return Output-String
 	 */
 	public static String escapeNewlines(String s) {
@@ -1033,22 +1013,22 @@ public class Command {
 	}
 
 	/** 
-	 * @return Gibt das Datenfeld links ({@code dataL}) zurück 
+	 * @return Gibt das Datenfeld links ({@code dataL}) zurück
 	 */
 	public int getDataL() { return dataL; }
 
 	/** 
-	 * @return Gibt das Datenfeld rechts ({@code dataR}) zurück 
+	 * @return Gibt das Datenfeld rechts ({@code dataR}) zurück
 	 */
 	public int getDataR() { return dataR; }
 
 	/** 
-	 * @return Gibt die Richtung zurück 
+	 * @return Gibt die Richtung zurück
 	 */
 	public int getDirection() { return direction; }
 
 	/** 
-	 * @return Liefert die Kommando-Sequenznummer 
+	 * @return Liefert die Kommando-Sequenznummer
 	 */
 	public byte getSeq() { return seq; }
 
@@ -1058,7 +1038,7 @@ public class Command {
 	public boolean hasBeenProcessed() { return hasBeenProcessed; }
 
 	/** 
-	 * @return Gibt das Subkommando des Kommandos zurück 
+	 * @return Gibt das Subkommando des Kommandos zurück
 	 */
 	public SubCode getSubCode() {
 		if (subCommandCode instanceof SubCode) {
@@ -1070,19 +1050,22 @@ public class Command {
 	}
 
 	/** 
-	 * Setzt das Feld dataL 
+	 * Setzt das Feld dataL
+	 * 
 	 * @param dataL 
 	 */
 	public void setDataL(int dataL) { this.dataL = dataL; }
 
 	/** 
-	 * Setzt das Feld dataR 
+	 * Setzt das Feld dataR
+	 * 
 	 * @param dataR 
 	 */
 	public void setDataR(int dataR) { this.dataR = dataR; } 
 	
 	/** 
 	 * Setzt die Kommandosequenznummer
+	 * 
 	 * @param seq 
 	 */
 	public void setSeq(byte seq) { this.seq = seq; }
@@ -1090,7 +1073,8 @@ public class Command {
 	/**
 	 * Setzt den Sub-Command-Code. Nur sinnvoll für Commands, die der Sim
 	 * senden wird.
-	 * @param sc SubCode
+	 * 
+	 * @param sc	SubCode
 	 */
 	public void setSubCmdCode(SubCode sc) {
 		try {
@@ -1105,6 +1089,7 @@ public class Command {
 	/**
 	 * Setzt die Nutzlast, die an das Command angehängt ist. Nur sinnvoll
 	 * für Commands, die der Sim senden wird.
+	 * 
 	 * @param payload Payload als byte-Array
 	 */
 	public void setPayload(byte[] payload) {
@@ -1117,6 +1102,7 @@ public class Command {
 	 * Flag, ob dieses Kommando fertig verarbeitet ist. Nützlich, wenn ein
 	 * Kommando in der Gegend herumgereicht wird und am Schluss festgestellt
 	 * werden soll, ob jemand das jetzt interpretiert hat oder nicht.
+	 * 
 	 * @param hasBeenProcessed 
 	 */
 	public void setHasBeenProcessed(boolean hasBeenProcessed) {
@@ -1125,6 +1111,7 @@ public class Command {
 
 	/**
 	 * Liest den Absender des Paketes aus
+	 * 
 	 * @return Absender-Id
 	 */
 	public BotID getFrom() {
@@ -1133,7 +1120,8 @@ public class Command {
 
 	/**
 	 * Setzt den Absender
-	 * @param from Absender-ID
+	 * 
+	 * @param from	Absender-ID
 	 */
 	public void setFrom(BotID from) {
 		this.from = from;
@@ -1141,6 +1129,7 @@ public class Command {
 
 	/**
 	 * Liest die Empfänger-ID des Paketes aus
+	 * 
 	 * @return Empfänger-ID
 	 */
 	public BotID getTo() {
@@ -1149,7 +1138,8 @@ public class Command {
 
 	/** 
 	 * Setzt die Empfänger-ID
-	 * @param to Empfänger-ID
+	 * 
+	 * @param to	Empfänger-ID
 	 */
 	public void setTo(BotID to) {
 		this.to = to;

--- a/ctSim/model/CommandOutputStream.java
+++ b/ctSim/model/CommandOutputStream.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import ctSim.util.BotID;
 import ctSim.util.Misc;
 
-/**
- * Output-Stream für Kommandos
- */
+/** Output-Stream für Kommandos */
 public class CommandOutputStream {
 	/** Puffer */
 	private final Map<Command.Code, Command> buffer = Misc.newMap();
@@ -38,7 +36,7 @@ public class CommandOutputStream {
 	/** Sequenznummer */
 	private byte seq = 0;
 
-	/** An wen gehen all die schoenen Pakete? */
+	/** An wen gehen die Pakete? */
 	private BotID to = new BotID();
 	
 	/**
@@ -51,7 +49,7 @@ public class CommandOutputStream {
 	}
 
 	/**
-	 * @param c Command-Code
+	 * @param c	Command-Code
 	 * @return Command
 	 */
 	public synchronized Command getCommand(Command.Code c) {
@@ -62,7 +60,8 @@ public class CommandOutputStream {
 
 	/**
 	 * Schreibt ein Kommando, toleriert null schweigend
-	 * @param c Kommando
+	 * 
+	 * @param c	Kommando
 	 * @throws IOException 
 	 */
 	private synchronized void write(Command c) throws IOException {
@@ -75,14 +74,15 @@ public class CommandOutputStream {
 
 	/**
 	 * Reihenfolge wichtig, sonst kommt der Bot-Steuercode durcheinander 
-	 * 1. Alles ausser SENS_ERROR und DONE
+	 * 1. Alles außer SENS_ERROR und DONE
 	 * 2. SENS_ERROR
 	 * 3. DONE
+	 * 
 	 * @throws IOException
 	 */
 	public synchronized void flush() throws IOException {
-		Command error = buffer.remove(Command.Code.SENS_ERROR); // ist evtl null
-		Command done = buffer.remove(Command.Code.DONE); // ist evtl null
+		Command error = buffer.remove(Command.Code.SENS_ERROR);	// ist evtl null
+		Command done = buffer.remove(Command.Code.DONE);	// ist evtl null
 
 		for (Command c : buffer.values())
 			write(c);
@@ -94,7 +94,8 @@ public class CommandOutputStream {
 	}
 
 	/** 
-	 * Setzt den Empfänger all der schoenen Kommandos
+	 * Setzt den Empfänger aller Kommandos
+	 * 
 	 * @param to
 	 */
 	public void setTo(BotID to) {
@@ -102,7 +103,8 @@ public class CommandOutputStream {
 	}
 
 	/** 
-	 * Liefert den Empfänger all der schoenen Kommandos
+	 * Liefert den Empfänger aller Kommandos
+	 * 
 	 * @return Empfänger-Id
 	 */
 	public BotID getTo() {

--- a/ctSim/model/Map.java
+++ b/ctSim/model/Map.java
@@ -32,6 +32,7 @@ import ctSim.model.bots.Bot;
 
 /**
  * Modell der Karte, die der Bot von der Umgebung erstellt (MAP_AVAILABLE)
+ * 
  * @author Timo Sandmann (mail@timosandmann.de)
  */
 public class Map {
@@ -49,16 +50,14 @@ public class Map {
 	private Macroblock[][] macroblocks;
 	
 	/**
-	 * Ein Makroblock stellt einen macroblock_length * macroblock_length Byte grossen Teil der Map dar
+	 * Ein Makroblock stellt einen macroblock_length * macroblock_length Byte großen Teil der Map dar
 	 * und enthält die Sections der Map.
 	 */
 	private class Macroblock {
 		/** Sections dieses Makroblocks */
 		private Section[][] sections;
 		
-		/** 
-		 * Erzeugt einen neuen Makroblock 
-		 */
+		/** Erzeugt einen neuen Makroblock */
 		public Macroblock() {
 			int length_in_sections = macroblock_length / section_points;
 			this.sections = new Section[length_in_sections][length_in_sections];
@@ -71,10 +70,11 @@ public class Map {
 		
 		/**
 		 * Liefert die Section in der das Feld (x|y) liegt
-		 * @param x X-Koordinate relativ zum Makroblock
-		 * @param y Y-Koordinate relativ zum Makroblock
+		 * 
+		 * @param x	X-Koordinate relativ zum Makroblock
+		 * @param y	Y-Koordinate relativ zum Makroblock
 		 * @return Section des gewünschten Feldes
-		 * @throws MapException falls auf eine Section ausserhalb des Makroblocks zugegriffen wird
+		 * @throws MapException falls auf eine Section außerhalb des Makroblocks zugegriffen wird
 		 */
 		public Section getSection(int x, int y) throws MapException {
 			int index_x = x / section_points;
@@ -88,8 +88,9 @@ public class Map {
 		}
 		
 		/**
-		 * Schreibt die Daten (aller Sections) dieses Makroblocks in einen Byte-Stream 
-		 * @param stream Stream, dem die Makroblock-Daten angehängt werden
+		 * Schreibt die Daten (aller Sections) dieses Makroblocks in einen Byte-Stream
+		 * 
+		 * @param stream	Stream, dem die Makroblock-Daten angehängt werden
 		 * @throws IOException falls beim Schreiben in den Stream ein Fehler auftritt
 		 */
 		public void toByteStream(OutputStream stream) throws IOException {
@@ -102,7 +103,7 @@ public class Map {
 	}
 	
 	/**
-	 * Eine Section stellt einen section_points * section_points Byte grossen Teil der Map dar,
+	 * Eine Section stellt einen section_points * section_points Byte großen Teil der Map dar,
 	 * enthält die Felder der Map und liegt in einem Makroblock. 
 	 */
 	private class Section {
@@ -118,10 +119,11 @@ public class Map {
 		
 		/**
 		 * Gibt einen Feld-Wert zurück
-		 * @param x X-Index des Feldes innerhalb der Section
-		 * @param y Y-Index des Feldes innerhalb der Section
+		 * 
+		 * @param x	X-Index des Feldes innerhalb der Section
+		 * @param y	Y-Index des Feldes innerhalb der Section
 		 * @return Feld (x|y) dieser Section
-		 * @throws MapException falls auf ein Feld ausserhalb der Section zugegriffen wird
+		 * @throws MapException falls auf ein Feld außerhalb der Section zugegriffen wird
 		 */
 		public byte getField(int x, int y) throws MapException {
 			if (x >= section_points || y >= section_points) {
@@ -132,10 +134,11 @@ public class Map {
 		
 		/**
 		 * Schreibt einen Feld-Wert in die Section
-		 * @param x X-Index des Feldes innerhalb der Section
-		 * @param y Y-Index des Feldes innerhalb der Section
+		 * 
+		 * @param x	X-Index des Feldes innerhalb der Section
+		 * @param y	Y-Index des Feldes innerhalb der Section
 		 * @param value zu schreibender Wert
-		 * @throws MapException falls auf ein Feld ausserhalb der Section zugegriffen wird
+		 * @throws MapException falls auf ein Feld außerhalb der Section zugegriffen wird
 		 */
 		public void setField(int x, int y, byte value) throws MapException {
 			if (x >= section_points || y >= section_points) {
@@ -145,8 +148,9 @@ public class Map {
 		}
 		
 		/**
-		 * Schreibt die Daten dieser Section in einen Byte-Stream 
-		 * @param stream Stream, dem die Section-Daten angehängt werden
+		 * Schreibt die Daten dieser Section in einen Byte-Stream
+		 * 
+		 * @param stream	Stream, dem die Section-Daten angehängt werden
 		 * @throws IOException falls beim Schreiben in den Stream ein Fehler auftritt
 		 */
 		public void toByteStream(OutputStream stream) throws IOException {
@@ -160,10 +164,11 @@ public class Map {
 	
 	/**
 	 * Erstellt eine leere Map mit den folgenden Parametern:
-	 * @param size Größe der Karte [m]
-	 * @param resolution Aufloesung der Karte [Punkte / m]
-	 * @param section_points Kantenlänge einer Section [Punkte]
-	 * @param macroblock_length Kantenlänge eines Macroblocks [Punkte]
+	 * 
+	 * @param size	Größe der Karte [m]
+	 * @param resolution	Auflösung der Karte [Punkte / m]
+	 * @param section_points	Kantenlänge einer Section [Punkte]
+	 * @param macroblock_length	Kantenlänge eines Macroblocks [Punkte]
 	 */
 	public Map(float size, int resolution, int section_points, int macroblock_length) {
 		this.size = size;
@@ -173,17 +178,18 @@ public class Map {
 		
 		final int length_in_macroblocks = (int)(this.size * this.resolution / this.macroblock_length);
 		this.macroblocks = new Macroblock[length_in_macroblocks][length_in_macroblocks];
-		// Makrobloecke werden on demand angelegt in access_field()
+		// Makroblöcke werden on demand angelegt in access_field()
 	}
 	
 	/**
 	 * Greift auf ein Map-Feld lesend oder schreibend zu
-	 * @param x Map-Koordinate X
-	 * @param y Map-Koordinate Y
-	 * @param value zu schreibender Wert (falls set == true)
-	 * @param set lesender (false) oder schreibender (true) Zugriff
+	 * 
+	 * @param x	Map-Koordinate X
+	 * @param y	Map-Koordinate Y
+	 * @param value	zu schreibender Wert (falls set == true)
+	 * @param set	lesender (false) oder schreibender (true) Zugriff
 	 * @return Wert des Feldes (fall set == false)
-	 * @throws MapException falls auf ein Feld ausserhalb der Karte zugegriffen wird
+	 * @throws MapException falls auf ein Feld außerhalb der Karte zugegriffen wird
 	 */
 	private byte access_field(int x, int y, byte value, boolean set) throws MapException {
 		int mb_index_x = x / macroblock_length;
@@ -214,7 +220,8 @@ public class Map {
 	
 	/** 
 	 * Wandelt eine Welt-Koordinate in eine Map-Koordinate um
-	 * @param koord Welt-Koordinate
+	 * 
+	 * @param koord	Welt-Koordinate
 	 * @return Map-Koordinate
 	 */
 	private int world_to_map(int koord) {
@@ -224,11 +231,12 @@ public class Map {
 	
 	/**
 	 * Trägt die Daten eines Parcours in die Karte ein. Als Urpsrung wird das Startfeld 
-	 * verwendet, das zum Bot der angegebenen Nr. gehört. 
-	 * @param parcours zu verwendender Parcours 
-	 * @param bot Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
-	 * @param free Wert, mit dem freie Felder eingetragen werden (z.B. 100)
-	 * @param occupied Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
+	 * verwendet, das zum Bot der angegebenen Nr. gehört.
+	 * 
+	 * @param parcours	zu verwendender Parcours 
+	 * @param bot	Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
+	 * @param free	Wert, mit dem freie Felder eingetragen werden (z.B. 100)
+	 * @param occupied	Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
 	 * @throws MapException im Fehlerfall
 	 */
 	public void createFromParcours(Parcours parcours, int bot, int free,
@@ -236,7 +244,7 @@ public class Map {
 
 		if (parcours.getHeightInM() > this.size
 				|| parcours.getHeightInM() > this.size) {
-			/* Parcours ist zu gross */
+			/* Parcours ist zu groß */
 			throw new MapException("Parcours " + parcours
 					+ " ist zu gross, max " + this.size + " m x " + this.size
 					+ " m möglich");
@@ -297,10 +305,11 @@ public class Map {
 	/**
 	 * Trägt die Daten eines Parcours in die Karte ein. Als Urpsrung wird das Startfeld 
 	 * des angegebenen Bots verwendet.
-	 * @param parcours zu verwendender Parcours 
-	 * @param bot Bot, dessen Startfeld als Koordinatenursprung der Map benutzt wird
-	 * @param free Wert, mit dem freie Felder eingetragen werden (z.B. 100)
-	 * @param occupied Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
+	 * 
+	 * @param parcours	zu verwendender Parcours
+	 * @param bot	Bot, dessen Startfeld als Koordinatenursprung der Map benutzt wird
+	 * @param free	Wert, mit dem freie Felder eingetragen werden (z.B. 100)
+	 * @param occupied	Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
 	 * @throws MapException im Fehlerfall
 	 */
 	public void createFromParcours(Parcours parcours, Bot bot, int free,
@@ -311,8 +320,9 @@ public class Map {
 	}
 	
 	/**
-	 * Schreibt die komplette Map in einen Byte-Stream 
-	 * @param stream Stream, dem die Map-Daten angehängt werden
+	 * Schreibt die komplette Map in einen Byte-Stream
+	 * 
+	 * @param stream	Stream, dem die Map-Daten angehängt werden
 	 * @throws IOException falls beim Schreiben in den Stream ein Fehler auftritt
 	 */
 	private void toByteStream(OutputStream stream) throws IOException {
@@ -331,7 +341,8 @@ public class Map {
 	
 	/**
 	 * Exportiert die Map in eine Datei (Bot-Format)
-	 * @param file Datei
+	 * 
+	 * @param file	Datei
 	 * @throws IOException falls beim Schreiben in die Datei etwas schief ging
 	 */
 	public void exportToFile(File file) throws IOException {
@@ -347,6 +358,7 @@ public class Map {
 	
 	/**
 	 * Exportiert die Map in eine auszuwählende Datei (Bot-Format)
+	 * 
 	 * @throws IOException falls beim Schreiben in die Datei etwas schief ging
 	 */
 	public void export() throws IOException {
@@ -375,23 +387,20 @@ public class Map {
 		exportToFile(file);
 	}
 	
-	/**
-	 * Map-Exceptions
-	 */
+	/** Map-Exceptions */
 	public class MapException extends Throwable {
 		/** ID */
 		private static final long serialVersionUID = 141554206659442950L;
 
-		/**
-		 * Map-Exception ohne Fehlermeldung
-		 */
+		/** Map-Exception ohne Fehlermeldung */
 		public MapException() {
 			super();
 		}
 
 		/**
 		 * Map-Exception mit Fehlermeldung
-		 * @param msg Fehlermeldung
+		 * 
+		 * @param msg	Fehlermeldung
 		 */
 		public MapException(String msg) {
 			super(msg);

--- a/ctSim/model/Obstacle.java
+++ b/ctSim/model/Obstacle.java
@@ -47,9 +47,7 @@ public abstract interface Obstacle {
 	 */
 	public abstract Vector3d getHeadingInWorldCoord();
 	
-	/**
-	 * Erzeugt die 3D-Repräsentation eines Objektes
-	 */
+	/** Erzeugt die 3D-Repräsentation eines Objektes */
 	//public abstract void createBranchGroup();
 	
 	/**

--- a/ctSim/model/Parcours.java
+++ b/ctSim/model/Parcours.java
@@ -111,7 +111,7 @@ public class Parcours {
 	final private ParcoursLoader parcoursLoader;
 
 	/**
-	 * Erzeugt einen neuen, leeren Parcours.
+	 * Erzeugt einen neuen, leeren Parcours
 	 * 
 	 * @param parcoursLoader ParcoursLoader, der den Parcours erzeugt hat
 	 */
@@ -146,7 +146,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt ein Startfeld auf belegt.
+	 * Setzt ein Startfeld auf belegt
 	 * 
 	 * @param bot
 	 *            Zeiger auf Bot, der das Startfeld belegt
@@ -161,7 +161,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Gibt ein Startfeld wieder frei.
+	 * Gibt ein Startfeld wieder frei
 	 * 
 	 * @param bot
 	 *            Zeiger auf Bot, der auf dem Startfeld steht oder gestartet ist
@@ -183,7 +183,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt die Parcoursbreite in Gittereinheiten.
+	 * Setzt die Parcoursbreite in Gittereinheiten
 	 * 
 	 * @param dimX1
 	 *            Breite in Gittereinheiten
@@ -216,7 +216,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt die Parcourshöhe in Gittereinheiten.
+	 * Setzt die Parcourshöhe in Gittereinheiten
 	 * 
 	 * @param dimY1
 	 *            Höhe in Gittereinheiten
@@ -226,7 +226,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt ein Hindernis ein.
+	 * Fügt ein Hindernis ein
 	 * 
 	 * @param obstacle
 	 *            Das Hindernis
@@ -240,7 +240,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt ein Hindernis ein.
+	 * Fügt ein Hindernis ein
 	 * 
 	 * @param obstacle
 	 *            Das Hindernis
@@ -256,7 +256,7 @@ public class Parcours {
 	}
 	
 	/**
-	 * Fügt ein bewegliches Hindernis ein.
+	 * Fügt ein bewegliches Hindernis ein
 	 * 
 	 * @param obstacle
 	 *            Das Hindernis
@@ -274,7 +274,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt ein Stück Boden ein.
+	 * Fügt ein Stück Boden ein
 	 * 
 	 * @param floor
 	 *            der Boden
@@ -290,7 +290,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt eine Node ein.
+	 * Fügt eine Node ein
 	 * 
 	 * @param node
 	 *            Die Node
@@ -322,7 +322,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt eine Node ein.
+	 * Fügt eine Node ein
 	 * 
 	 * @param node
 	 *            Die Node
@@ -338,7 +338,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt eine Darstellung der Lichtquelle ein.
+	 * Fügt eine Darstellung der Lichtquelle ein
 	 * 
 	 * @param light
 	 *            Die Lichtquelle
@@ -354,7 +354,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt eine Lichtquelle ein.
+	 * Fügt eine Lichtquelle ein
 	 * 
 	 * @param light
 	 *            Die Lichtquelle
@@ -364,7 +364,7 @@ public class Parcours {
 	}
 	
 	/**
-	 * Fügt eine Darstellung der Landmarke ein.
+	 * Fügt eine Darstellung der Landmarke ein
 	 * 
 	 * @param bps Die Landmarke
 	 * @param x   X-Achse im Parcours-Gitter
@@ -376,7 +376,7 @@ public class Parcours {
 	}
 	
 	/**
-	 * Fügt eine Landmarke für BPS ein.
+	 * Fügt eine Landmarke für BPS ein
 	 * 
 	 * @param bps Landmarke
 	 */
@@ -385,7 +385,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Erzeugt ein bewegliches Objekt.
+	 * Erzeugt ein bewegliches Objekt
 	 * 
 	 * @param x X-Koordinate
 	 * @param y Y-Koordinate
@@ -423,7 +423,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Legt die Startposition eines Bots fest.
+	 * Legt die Startposition eines Bots fest
 	 * 
 	 * @param bot
 	 *            Nummer des Bots (fängt bei 0 an zu zählen)
@@ -440,7 +440,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Legt die Startrichtung eines Bots fest.
+	 * Legt die Startrichtung eines Bots fest
 	 * 
 	 * @param bot
 	 *            Nummer des Bots (fängt bei 0 an zu zählen)
@@ -502,7 +502,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Nummer des Startfeldes zu einem Bot.
+	 * Liefert die Nummer des Startfeldes zu einem Bot
 	 * 
 	 * @param bot
 	 *            Referenz auf Bot
@@ -518,7 +518,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Startposition eines vorhandenen Bots.
+	 * Liefert die Startposition eines vorhandenen Bots
 	 * 
 	 * @param bot
 	 *            Bot-Nummer
@@ -547,7 +547,7 @@ public class Parcours {
 		if (bot < BOTS) {
 			pos = new Vector3d(startHeadings[bot][0], startHeadings[bot][1], 0.0f);
 		} else {
-			// sonst leifer die Default-Richtung
+			// sonst liefere die Default-Richtung
 			pos = new Vector3d(startHeadings[0][0], startHeadings[0][1], 0.0f);
 		}
 
@@ -591,7 +591,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Prüft, ob ein Punkt innerhalb des Zielfeldes liegt.
+	 * Prüft, ob ein Punkt innerhalb des Zielfeldes liegt
 	 * 
 	 * @param pos
 	 * @return true, falls ja
@@ -611,7 +611,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt ein Loch hinzu.
+	 * Fügt ein Loch hinzu
 	 * 
 	 * @param x
 	 * @param y
@@ -621,7 +621,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Prüft, ob ein Punkt über einem Loch liegt.
+	 * Prüft, ob ein Punkt über einem Loch liegt
 	 * 
 	 * @param pos
 	 * @return true, wenn der Bot über dem loch steht
@@ -648,7 +648,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt eine Parcours-Map.
+	 * Setzt eine Parcours-Map
 	 * 
 	 * @param parcoursMap
 	 *            die neue Map
@@ -768,8 +768,8 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die kuerzeste Distanz von einem gegebenen Punkt (in
-	 * Gitterkoordinaten) zum Ziel.
+	 * Liefert die kürzeste Distanz von einem gegebenen Punkt (in
+	 * Gitterkoordinaten) zum Ziel
 	 * 
 	 * @param from
 	 *            Startpunkt in Weltkoordinaten
@@ -788,7 +788,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel.
+	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel
 	 * 
 	 * @param from
 	 *            Startpunkt in weltkoordinaten
@@ -799,7 +799,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel.
+	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel
 	 * 
 	 * @param from
 	 *            Startpunkt in weltkoordinaten
@@ -839,7 +839,7 @@ public class Parcours {
 	}
 	
 	/** 
-	 * Rechnet eine Block-Koordinate in eine Welt-Koordinate um.
+	 * Rechnet eine Block-Koordinate in eine Welt-Koordinate um
 	 * 
 	 * @param koord Block-Koordinate
 	 * @return Welt-Koordinate [mm]
@@ -863,7 +863,7 @@ public class Parcours {
 	}
 	
 	/**
-	 * Rechnet eine Welt-Koordinate in eine globale Position um.
+	 * Rechnet eine Welt-Koordinate in eine globale Position um
 	 * 
 	 * @param worldPos Welt-Position (wie von Java3D verwendet)
 	 * @return globale Position (wie zur Lokalisierung verwendet) / Blocks

--- a/ctSim/model/Parcours.java
+++ b/ctSim/model/Parcours.java
@@ -39,7 +39,7 @@ import ctSim.util.Misc;
 /**
  * Repräsentiert einen Parcours für die Bots Wird zum Laden eines solchen
  * benötigt. Des Weiteren stehen hier auch Informationen über Start- und
- * Zielpunkte der Bots
+ * Zielpunkte der Bots.
  * 
  * @author bbe (bbe@heise.de)
  * 
@@ -52,12 +52,11 @@ public class Parcours {
 	 * <p>
 	 * Breite einer Gittereinheit (eines Blocks) in Meter. Da die Blöcke
 	 * immer quadratisch sind, ist die Breite auch die Höhe.
-	 * </p>
-	 * <p>
+	 * 
 	 * Idee: ct-Bot ist 12cm breit, wir setzen das Gitter auf 24cm, damit der
 	 * Bot auf dem engstmöglichen Durchgang (1 Block breit) möglichst
 	 * viel Spielraum hat nach links und rechts (oben und unten), aber dass
-	 * gerade keine zwei Bots mehr aneinander vorbeikönnen.
+	 * gerade keine zwei Bots mehr aneinander vorbei können.
 	 * </p>
 	 */
 	private final float blockSizeInM = 0.24f;
@@ -99,7 +98,7 @@ public class Parcours {
 	/** Zielpositionen */
 	private List<Vector2d> finishPositions = Misc.newList();
 
-	/** Liste mit allen Abgruenden */
+	/** Liste mit allen Abgründen */
 	private Vector<Vector2d> holes = new Vector<Vector2d>();
 
 	/**
@@ -112,7 +111,8 @@ public class Parcours {
 	final private ParcoursLoader parcoursLoader;
 
 	/**
-	 * Erzeugt einen neuen, leeren Parcours
+	 * Erzeugt einen neuen, leeren Parcours.
+	 * 
 	 * @param parcoursLoader ParcoursLoader, der den Parcours erzeugt hat
 	 */
 	public Parcours(ParcoursLoader parcoursLoader) {
@@ -146,7 +146,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt ein Startfeld auf belegt
+	 * Setzt ein Startfeld auf belegt.
 	 * 
 	 * @param bot
 	 *            Zeiger auf Bot, der das Startfeld belegt
@@ -161,7 +161,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Gibt ein Startfeld wieder frei
+	 * Gibt ein Startfeld wieder frei.
 	 * 
 	 * @param bot
 	 *            Zeiger auf Bot, der auf dem Startfeld steht oder gestartet ist
@@ -183,7 +183,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt die Parcoursbreite in Gittereinheiten
+	 * Setzt die Parcoursbreite in Gittereinheiten.
 	 * 
 	 * @param dimX1
 	 *            Breite in Gittereinheiten
@@ -193,7 +193,6 @@ public class Parcours {
 	}
 
 	/**
-	 * 
 	 * @return Liefert die Parcourshöhe in Gittereinheiten zurück
 	 */
 	public int getHeightInBlocks() {
@@ -217,7 +216,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt die Parcourshöhe in Gittereinheiten
+	 * Setzt die Parcourshöhe in Gittereinheiten.
 	 * 
 	 * @param dimY1
 	 *            Höhe in Gittereinheiten
@@ -227,10 +226,10 @@ public class Parcours {
 	}
 
 	/**
-* Fügt ein Hinderniss ein
+	 * Fügt ein Hindernis ein.
 	 * 
 	 * @param obstacle
-	 *            Das Hinderniss
+	 *            Das Hindernis
 	 * @param x
 	 *            X-Achse im Parcours-Gitter
 	 * @param y
@@ -241,10 +240,10 @@ public class Parcours {
 	}
 
 	/**
-* Fügt ein Hinderniss ein
+	 * Fügt ein Hindernis ein.
 	 * 
 	 * @param obstacle
-	 *            Das Hinderniss
+	 *            Das Hindernis
 	 * @param x
 	 *            X-Achse im Parcours-Gitter
 	 * @param y
@@ -257,10 +256,10 @@ public class Parcours {
 	}
 	
 	/**
-* Fügt ein bewegliches Hinderniss ein
+	 * Fügt ein bewegliches Hindernis ein.
 	 * 
 	 * @param obstacle
-	 *            Das Hinderniss
+	 *            Das Hindernis
 	 * @param x
 	 *            X-Koordinate
 	 * @param y
@@ -275,7 +274,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt ein Stück Boden ein
+	 * Fügt ein Stück Boden ein.
 	 * 
 	 * @param floor
 	 *            der Boden
@@ -291,7 +290,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt eine Node ein
+	 * Fügt eine Node ein.
 	 * 
 	 * @param node
 	 *            Die Node
@@ -303,7 +302,7 @@ public class Parcours {
 	 *            Z-Achse absolut; positiv ist vom Boden Richtung Bot +
 	 *            Betrachter, negativ vom Boden weg vom Betrachter
 	 * @param bg
-	 *            BranchGropu, in die das Objekt rein soll
+	 *            BranchGroup, in die das Objekt rein soll
 	 */
 	public void addNode(Node node, float x, float y, float z, BranchGroup bg) {
 		Transform3D translate = new Transform3D();
@@ -323,7 +322,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt eine Node ein
+	 * Fügt eine Node ein.
 	 * 
 	 * @param node
 	 *            Die Node
@@ -339,7 +338,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt eine Darstellung der Lichtquelle ein
+	 * Fügt eine Darstellung der Lichtquelle ein.
 	 * 
 	 * @param light
 	 *            Die Lichtquelle
@@ -355,7 +354,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt eine Lichtquelle ein
+	 * Fügt eine Lichtquelle ein.
 	 * 
 	 * @param light
 	 *            Die Lichtquelle
@@ -365,7 +364,7 @@ public class Parcours {
 	}
 	
 	/**
-* Fügt eine Darstellung der Landmarke ein
+	 * Fügt eine Darstellung der Landmarke ein.
 	 * 
 	 * @param bps Die Landmarke
 	 * @param x   X-Achse im Parcours-Gitter
@@ -377,7 +376,8 @@ public class Parcours {
 	}
 	
 	/**
-* Fügt eine Landmarke für BPS ein
+	 * Fügt eine Landmarke für BPS ein.
+	 * 
 	 * @param bps Landmarke
 	 */
 	public void addBPSLight(Node bps) {
@@ -385,7 +385,8 @@ public class Parcours {
 	}
 
 	/**
-	 * Erzeugt ein bewegliches Objekt
+	 * Erzeugt ein bewegliches Objekt.
+	 * 
 	 * @param x X-Koordinate
 	 * @param y Y-Koordinate
 	 */
@@ -422,7 +423,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Legt die Startposition eines Bots fest
+	 * Legt die Startposition eines Bots fest.
 	 * 
 	 * @param bot
 	 *            Nummer des Bots (fängt bei 0 an zu zählen)
@@ -439,7 +440,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Legt die Startrichtung eines Bots fest
+	 * Legt die Startrichtung eines Bots fest.
 	 * 
 	 * @param bot
 	 *            Nummer des Bots (fängt bei 0 an zu zählen)
@@ -475,7 +476,7 @@ public class Parcours {
 
 	/**
 	 * Liefert die Startposition für einen neuen Bots Wenn keine festgelegt
-	 * wurde, dann die Default-Position (0)
+	 * wurde, dann die Default-Position (0).
 	 * 
 	 * @param bot
 	 *            Bot-Nummer
@@ -501,7 +502,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Nummer des Startfeldes zu einem Bot
+	 * Liefert die Nummer des Startfeldes zu einem Bot.
 	 * 
 	 * @param bot
 	 *            Referenz auf Bot
@@ -517,7 +518,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Startposition eines vorhandenen Bots
+	 * Liefert die Startposition eines vorhandenen Bots.
 	 * 
 	 * @param bot
 	 *            Bot-Nummer
@@ -536,7 +537,7 @@ public class Parcours {
 
 	/**
 	 * Liefert die Startrichtung eines Bots Wenn keine festgelegt wurde, dann
-	 * die Default-Position (0)
+	 * die Default-Position (0).
 	 * 
 	 * @param bot
 	 * @return Die Startrichtung
@@ -562,7 +563,7 @@ public class Parcours {
 	}
 
 	/**
-* Fügt eine neue Zielposition hinzu
+	 * Fügt eine neue Zielposition hinzu
 	 * 
 	 * @param x
 	 * @param y
@@ -590,7 +591,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Prüft, ob ein Punkt innerhalb des Zielfeldes liegt
+	 * Prüft, ob ein Punkt innerhalb des Zielfeldes liegt.
 	 * 
 	 * @param pos
 	 * @return true, falls ja
@@ -610,7 +611,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Fügt ein Loch hinzu
+	 * Fügt ein Loch hinzu.
 	 * 
 	 * @param x
 	 * @param y
@@ -620,7 +621,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Prüft, ob ein Punkt über einem Loch liegt
+	 * Prüft, ob ein Punkt über einem Loch liegt.
 	 * 
 	 * @param pos
 	 * @return true, wenn der Bot über dem loch steht
@@ -647,7 +648,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Setzt eine Parcours-Map
+	 * Setzt eine Parcours-Map.
 	 * 
 	 * @param parcoursMap
 	 *            die neue Map
@@ -668,8 +669,8 @@ public class Parcours {
 	}
 
 	/**
-	 * @return Liefert einen stark vereinfachten Parcours zurück. das Array
-	 *         enthält nur 0 (freies Feld) und 1 (blockiertes Feld)
+	 * @return Liefert einen stark vereinfachten Parcours zurück. Das Array
+	 *         enthält nur 0 (freies Feld) und 1 (blockiertes Feld).
 	 */
 	int[][] getFlatParcours() {
 		int[][] parcoursMapSimple = new int[getWidthInBlocks()][getHeightInBlocks()];
@@ -708,7 +709,7 @@ public class Parcours {
 
 	/**
 	 * @return Liefert einen stark vereinfachten Parcours zurück. Das Array
-	 *         enthält nur 0 (freies Feld), 1 (blockiertes Feld) und 2 (Loch)
+	 *         enthält nur 0 (freies Feld), 1 (blockiertes Feld) und 2 (Loch).
 	 */
 	public int[][] getFlatParcoursWithHoles() {
 		int[][] parcoursMapSimple = new int[getWidthInBlocks()][getHeightInBlocks()];
@@ -753,22 +754,22 @@ public class Parcours {
 	
 	/**
 	 * Liefert die kuerzeste Distanz von einem gegebenen Punkt (in
-	 * Gitterkoordinaten) zum Ziel
+	 * Gitterkoordinaten) zum Ziel.
 	 * 
 	 * @param from
 	 *            Startpunkt in Weltkoordinaten
 	 * @return Distanz (ohne Drehungen) in Metern
 	 */
 	public double getShortestDistanceToFinish(Vector3d from) {
-		// LODO: z wird ignoriert -- wird nicht mehr klappen, wenn der Bot
+		// TODO: z wird ignoriert -- wird nicht mehr klappen, wenn der Bot
 		// (hypothetisch) mal Rampen hochfährt und sich auf verschiedenen
-		// Ebenen bewegt
+		// Ebenen bewegt.
 		return getShortestDistanceToFinish(new Vector2d(from.x, from.y));
 	}
 
 	/**
 	 * Liefert die kuerzeste Distanz von einem gegebenen Punkt (in
-	 * Gitterkoordinaten) zum Ziel
+	 * Gitterkoordinaten) zum Ziel.
 	 * 
 	 * @param from
 	 *            Startpunkt in Weltkoordinaten
@@ -787,7 +788,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert den kuerzesten Pfad von einem bestimmten Punkt aus zum Ziel
+	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel.
 	 * 
 	 * @param from
 	 *            Startpunkt in weltkoordinaten
@@ -798,7 +799,7 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert den kuerzesten Pfad von einem bestimmten Punkt aus zum Ziel
+	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel.
 	 * 
 	 * @param from
 	 *            Startpunkt in weltkoordinaten
@@ -833,12 +834,13 @@ public class Parcours {
 			}
 		}
 
-		// finde die kuerzeste Verbindung
+		// finde die kürzeste Verbindung
 		return shortestPath;
 	}
 	
 	/** 
-	 * Rechnet eine Block-Koordinate in eine Welt-Koordinate um
+	 * Rechnet eine Block-Koordinate in eine Welt-Koordinate um.
+	 * 
 	 * @param koord Block-Koordinate
 	 * @return Welt-Koordinate [mm]
 	 */
@@ -848,6 +850,7 @@ public class Parcours {
 	
 	/**
 	 * Liefert die Startposition zu einer Bot-Nr.
+	 * 
 	 * @param bot Nummer des Bots [0, 2]
 	 * @return {X, Y}
 	 */
@@ -860,7 +863,8 @@ public class Parcours {
 	}
 	
 	/**
-	 * Rechnet eine Welt-Koordinate in eine globale Position um
+	 * Rechnet eine Welt-Koordinate in eine globale Position um.
+	 * 
 	 * @param worldPos Welt-Position (wie von Java3D verwendet)
 	 * @return globale Position (wie zur Lokalisierung verwendet) / Blocks
 	 */

--- a/ctSim/model/Parcours.java
+++ b/ctSim/model/Parcours.java
@@ -41,7 +41,7 @@ import ctSim.util.Misc;
  * benötigt. Des Weiteren stehen hier auch Informationen über Start- und
  * Zielpunkte der Bots.
  * 
- * @author bbe (bbe@heise.de)
+ * @author Benjamin Benz (bbe@heise.de)
  * 
  */
 public class Parcours {
@@ -65,7 +65,7 @@ public class Parcours {
 	 * Anzahl der Startpositionen für Bots. Dir Position 0 ist die Default
 	 * Position, ab 1 für die Wettkampfbots.
 	 */
-	public static final int BOTS = 3; // ParcoursLoader kann max 2 Startplätze erzeugen, darum hardcoded auf 3
+	public static final int BOTS = 3;	// ParcoursLoader kann max 2 Startplätze erzeugen, darum hardcoded auf 3
 
 	/** Enthält alle Hindernisse */
 	private BranchGroup ObstBG;
@@ -148,8 +148,7 @@ public class Parcours {
 	/**
 	 * Setzt ein Startfeld auf belegt
 	 * 
-	 * @param bot
-	 *            Zeiger auf Bot, der das Startfeld belegt
+	 * @param bot	Zeiger auf Bot, der das Startfeld belegt
 	 */
 	public void setStartFieldUsed(Bot bot) {
 		for (int i = 1; i < BOTS; i++) {
@@ -163,8 +162,7 @@ public class Parcours {
 	/**
 	 * Gibt ein Startfeld wieder frei
 	 * 
-	 * @param bot
-	 *            Zeiger auf Bot, der auf dem Startfeld steht oder gestartet ist
+	 * @param bot	Zeiger auf Bot, der auf dem Startfeld steht oder gestartet ist
 	 */
 	public void setStartFieldUnused(Bot bot) {
 		for (int i = 1; i < BOTS; i++) {
@@ -185,8 +183,7 @@ public class Parcours {
 	/**
 	 * Setzt die Parcoursbreite in Gittereinheiten
 	 * 
-	 * @param dimX1
-	 *            Breite in Gittereinheiten
+	 * @param dimX1	Breite in Gittereinheiten
 	 */
 	public void setDimX(int dimX1) {
 		dimX = dimX1;
@@ -200,16 +197,14 @@ public class Parcours {
 	}
 
 	/**
-	 * @return Liefert die Breite (X-Größe) des Parcours in Meter
-	 *         zurück
+	 * @return Liefert die Breite (X-Größe) des Parcours in Meter zurück
 	 */
 	public float getWidthInM() {
 		return dimX * blockSizeInM;
 	}
 
 	/**
-	 * @return Liefert die Höhe (Y-Größe) des Parcours in Meter
-	 *         zurück
+	 * @return Liefert die Höhe (Y-Größe) des Parcours in Meter zurück
 	 */
 	public float getHeightInM() {
 		return dimY * blockSizeInM;
@@ -218,8 +213,7 @@ public class Parcours {
 	/**
 	 * Setzt die Parcourshöhe in Gittereinheiten
 	 * 
-	 * @param dimY1
-	 *            Höhe in Gittereinheiten
+	 * @param dimY1	Höhe in Gittereinheiten
 	 */
 	public void setDimY(int dimY1) {
 		dimY = dimY1;
@@ -228,12 +222,9 @@ public class Parcours {
 	/**
 	 * Fügt ein Hindernis ein
 	 * 
-	 * @param obstacle
-	 *            Das Hindernis
-	 * @param x
-	 *            X-Achse im Parcours-Gitter
-	 * @param y
-	 *            Y-Achse im Parcours-Gitter
+	 * @param obstacle	Das Hindernis
+	 * @param x			X-Achse im Parcours-Gitter
+	 * @param y			Y-Achse im Parcours-Gitter
 	 */
 	public void addObstacle(Node obstacle, float x, float y) {
 		addNode(obstacle, x, y, ObstBG);
@@ -242,14 +233,10 @@ public class Parcours {
 	/**
 	 * Fügt ein Hindernis ein
 	 * 
-	 * @param obstacle
-	 *            Das Hindernis
-	 * @param x
-	 *            X-Achse im Parcours-Gitter
-	 * @param y
-	 *            Y-Achse im Parcours-Gitter
-	 * @param z
-	 *            Z-Achse Absolut
+	 * @param obstacle	Das Hindernis
+	 * @param x			X-Achse im Parcours-Gitter
+	 * @param y			Y-Achse im Parcours-Gitter
+	 * @param z			Z-Achse absolut
 	 */
 	public void addObstacle(Node obstacle, float x, float y, float z) {
 		addNode(obstacle, x * blockSizeInM, y * blockSizeInM, z, ObstBG);
@@ -258,12 +245,9 @@ public class Parcours {
 	/**
 	 * Fügt ein bewegliches Hindernis ein
 	 * 
-	 * @param obstacle
-	 *            Das Hindernis
-	 * @param x
-	 *            X-Koordinate
-	 * @param y
-	 *            Y-Koordinate
+	 * @param obstacle	Das Hindernis
+	 * @param x			X-Koordinate
+	 * @param y			Y-Koordinate
 	 */
 	public void addMoveableObstacle(Node obstacle, float x, float y) {
 		BranchGroup bg = new BranchGroup();
@@ -276,14 +260,10 @@ public class Parcours {
 	/**
 	 * Fügt ein Stück Boden ein
 	 * 
-	 * @param floor
-	 *            der Boden
-	 * @param x
-	 *            X-Achse im Parcours-Gitter
-	 * @param y
-	 *            Y-Achse im Parcours-Gitter
-	 * @param z
-	 *            Z-Achse Absolut
+	 * @param floor	der Boden
+	 * @param x		X-Achse im Parcours-Gitter
+	 * @param y		Y-Achse im Parcours-Gitter
+	 * @param z		Z-Achse absolut
 	 */
 	public void addFloor(Node floor, float x, float y, float z) {
 		addNode(floor, x * blockSizeInM, y * blockSizeInM, z, terrainBG);
@@ -292,17 +272,12 @@ public class Parcours {
 	/**
 	 * Fügt eine Node ein
 	 * 
-	 * @param node
-	 *            Die Node
-	 * @param x
-	 *            X-Koordinate
-	 * @param y
-	 *            Y-Koordinate
-	 * @param z
-	 *            Z-Achse absolut; positiv ist vom Boden Richtung Bot +
-	 *            Betrachter, negativ vom Boden weg vom Betrachter
-	 * @param bg
-	 *            BranchGroup, in die das Objekt rein soll
+	 * @param node	Die Node
+	 * @param x		X-Koordinate
+	 * @param y		Y-Koordinate
+	 * @param z		Z-Achse absolut; positiv ist vom Boden Richtung Bot +
+	 * 				Betrachter, negativ vom Boden weg vom Betrachter
+	 * @param bg	BranchGroup, in die das Objekt rein soll
 	 */
 	public void addNode(Node node, float x, float y, float z, BranchGroup bg) {
 		Transform3D translate = new Transform3D();
@@ -324,14 +299,10 @@ public class Parcours {
 	/**
 	 * Fügt eine Node ein
 	 * 
-	 * @param node
-	 *            Die Node
-	 * @param x
-	 *            X-Achse im Parcours-Gitter
-	 * @param y
-	 *            Y-Achse im Parcours-Gitter
-	 * @param bg
-	 *            Gruppe in die das Objekt rein soll
+	 * @param node	Die Node
+	 * @param x		X-Achse im Parcours-Gitter
+	 * @param y		Y-Achse im Parcours-Gitter
+	 * @param bg	Gruppe in die das Objekt rein soll
 	 */
 	public void addNode(Node node, float x, float y, BranchGroup bg) {
 		addNode(node, x * blockSizeInM, y * blockSizeInM, 0.0f, bg);
@@ -340,14 +311,10 @@ public class Parcours {
 	/**
 	 * Fügt eine Darstellung der Lichtquelle ein
 	 * 
-	 * @param light
-	 *            Die Lichtquelle
-	 * @param x
-	 *            X-Achse im Parcours-Gitter
-	 * @param y
-	 *            Y-Achse im Parcours-Gitter
-	 * @param z
-	 *            Z-Achse im Parcours-Gitter
+	 * @param light	Die Lichtquelle
+	 * @param x		X-Achse im Parcours-Gitter
+	 * @param y		Y-Achse im Parcours-Gitter
+	 * @param z		Z-Achse im Parcours-Gitter
 	 */
 	public void addLight(Node light, float x, float y, float z) {
 		addNode(light, x * blockSizeInM, y * blockSizeInM, z, lightBG);
@@ -356,8 +323,7 @@ public class Parcours {
 	/**
 	 * Fügt eine Lichtquelle ein
 	 * 
-	 * @param light
-	 *            Die Lichtquelle
+	 * @param light	Die Lichtquelle
 	 */
 	public void addLight(Node light) {
 		lightBG.addChild(light);
@@ -366,10 +332,10 @@ public class Parcours {
 	/**
 	 * Fügt eine Darstellung der Landmarke ein
 	 * 
-	 * @param bps Die Landmarke
-	 * @param x   X-Achse im Parcours-Gitter
-	 * @param y   Y-Achse im Parcours-Gitter
-	 * @param z   Z-Achse im Parcours-Gitter
+	 * @param bps	Die Landmarke
+	 * @param x		X-Achse im Parcours-Gitter
+	 * @param y		Y-Achse im Parcours-Gitter
+	 * @param z		Z-Achse im Parcours-Gitter
 	 */
 	public void addBPSLight(Node bps, float x, float y, float z) {
 		addNode(bps, x * blockSizeInM, y * blockSizeInM, z, bpsBG);
@@ -378,7 +344,7 @@ public class Parcours {
 	/**
 	 * Fügt eine Landmarke für BPS ein
 	 * 
-	 * @param bps Landmarke
+	 * @param bps	Landmarke
 	 */
 	public void addBPSLight(Node bps) {
 		bpsBG.addChild(bps);
@@ -387,8 +353,8 @@ public class Parcours {
 	/**
 	 * Erzeugt ein bewegliches Objekt
 	 * 
-	 * @param x X-Koordinate
-	 * @param y Y-Koordinate
+	 * @param x	X-Koordinate
+	 * @param y	Y-Koordinate
 	 */
 	public void createMovableObject(float x, float y) {
 		parcoursLoader.createMovableObject(x, y);
@@ -425,12 +391,9 @@ public class Parcours {
 	/**
 	 * Legt die Startposition eines Bots fest
 	 * 
-	 * @param bot
-	 *            Nummer des Bots (fängt bei 0 an zu zählen)
-	 * @param x
-	 *            X-Koordinate
-	 * @param y
-	 *            Y-Koordinate
+	 * @param bot	Nummer des Bots (fängt bei 0 an zu zählen)
+	 * @param x		X-Koordinate
+	 * @param y		Y-Koordinate
 	 */
 	public void setStartPosition(int bot, int x, int y) {
 		if (bot <= BOTS - 1) {
@@ -442,11 +405,8 @@ public class Parcours {
 	/**
 	 * Legt die Startrichtung eines Bots fest
 	 * 
-	 * @param bot
-	 *            Nummer des Bots (fängt bei 0 an zu zählen)
-	 * @param dir
-	 *            Richtung in Grad. 0 entspricht (x=1, y=0) dann im
-	 *            Uhrzeigersinn
+	 * @param bot	Nummer des Bots (fängt bei 0 an zu zählen)
+	 * @param dir	Richtung in Grad. 0 entspricht (x=1, y=0) dann im Uhrzeigersinn
 	 */
 	public void setStartHeading(int bot, int dir) {
 		if (bot <= BOTS - 1) {
@@ -475,11 +435,10 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Startposition für einen neuen Bots Wenn keine festgelegt
-	 * wurde, dann die Default-Position (0).
+	 * Liefert die Startposition für einen neuen Bots
+	 * Wenn keine festgelegt wurde, dann die Default-Position (0).
 	 * 
-	 * @param bot
-	 *            Bot-Nummer
+	 * @param bot	Bot-Nummer
 	 * @return Die Startposition
 	 */
 	public Point3d getStartPosition(int bot) {
@@ -504,8 +463,7 @@ public class Parcours {
 	/**
 	 * Liefert die Nummer des Startfeldes zu einem Bot
 	 * 
-	 * @param bot
-	 *            Referenz auf Bot
+	 * @param bot	Referenz auf Bot
 	 * @return Nummer des Startfeldes, oder 0, falls Bot unbekannt
 	 */
 	public int getStartPositionNumber(Bot bot) {
@@ -520,8 +478,7 @@ public class Parcours {
 	/**
 	 * Liefert die Startposition eines vorhandenen Bots
 	 * 
-	 * @param bot
-	 *            Bot-Nummer
+	 * @param bot	Bot-Nummer
 	 * @return Die Startposition
 	 */
 	public Point3d getUsedStartPosition(int bot) {
@@ -536,8 +493,8 @@ public class Parcours {
 	}
 
 	/**
-	 * Liefert die Startrichtung eines Bots Wenn keine festgelegt wurde, dann
-	 * die Default-Position (0).
+	 * Liefert die Startrichtung eines Bots
+	 * Wenn keine festgelegt wurde, dann die Default-Position (0).
 	 * 
 	 * @param bot
 	 * @return Die Startrichtung
@@ -624,7 +581,7 @@ public class Parcours {
 	 * Prüft, ob ein Punkt über einem Loch liegt
 	 * 
 	 * @param pos
-	 * @return true, wenn der Bot über dem loch steht
+	 * @return true, wenn der Bot über dem Loch steht
 	 */
 	public boolean checkHole(Point3d pos) {
 		if ((pos.x < 0) || (pos.y < 0) || (pos.x > dimX * blockSizeInM) || (pos.y > dimY * blockSizeInM)) {
@@ -650,8 +607,7 @@ public class Parcours {
 	/**
 	 * Setzt eine Parcours-Map
 	 * 
-	 * @param parcoursMap
-	 *            die neue Map
+	 * @param parcoursMap	die neue Map
 	 */
 	void setParcoursMap(int[][] parcoursMap) {
 		this.parcoursMap = parcoursMap;
@@ -753,11 +709,10 @@ public class Parcours {
 	}	
 	
 	/**
-	 * Liefert die kuerzeste Distanz von einem gegebenen Punkt (in
+	 * Liefert die kürzeste Distanz von einem gegebenen Punkt (in
 	 * Gitterkoordinaten) zum Ziel.
 	 * 
-	 * @param from
-	 *            Startpunkt in Weltkoordinaten
+	 * @param from	Startpunkt in Weltkoordinaten
 	 * @return Distanz (ohne Drehungen) in Metern
 	 */
 	public double getShortestDistanceToFinish(Vector3d from) {
@@ -771,8 +726,7 @@ public class Parcours {
 	 * Liefert die kürzeste Distanz von einem gegebenen Punkt (in
 	 * Gitterkoordinaten) zum Ziel
 	 * 
-	 * @param from
-	 *            Startpunkt in Weltkoordinaten
+	 * @param from	Startpunkt in Weltkoordinaten
 	 * @return Distanz in Metern
 	 */
 	public double getShortestDistanceToFinish(Vector2d from) {
@@ -790,8 +744,7 @@ public class Parcours {
 	/**
 	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel
 	 * 
-	 * @param from
-	 *            Startpunkt in weltkoordinaten
+	 * @param from	Startpunkt in weltkoordinaten
 	 * @return Liste der Turningpoints (Gitterkoordinaten!!!)
 	 */
 	public Vector<TurningPoint> getShortestPath(Vector3d from) {
@@ -801,8 +754,7 @@ public class Parcours {
 	/**
 	 * Liefert den kürzesten Pfad von einem bestimmten Punkt aus zum Ziel
 	 * 
-	 * @param from
-	 *            Startpunkt in weltkoordinaten
+	 * @param from	Startpunkt in weltkoordinaten
 	 * @return Liste der Turningpoints (Gitterkoordinaten!!!)
 	 */
 	public Vector<TurningPoint> getShortestPath(Vector2d from) {
@@ -841,7 +793,7 @@ public class Parcours {
 	/** 
 	 * Rechnet eine Block-Koordinate in eine Welt-Koordinate um
 	 * 
-	 * @param koord Block-Koordinate
+	 * @param koord	Block-Koordinate
 	 * @return Welt-Koordinate [mm]
 	 */
 	public int blockToWorld(int koord) {
@@ -851,7 +803,7 @@ public class Parcours {
 	/**
 	 * Liefert die Startposition zu einer Bot-Nr.
 	 * 
-	 * @param bot Nummer des Bots [0, 2]
+	 * @param bot	Nummer des Bots [0, 2]
 	 * @return {X, Y}
 	 */
 	public int[] getStartPositions(int bot) {
@@ -865,7 +817,7 @@ public class Parcours {
 	/**
 	 * Rechnet eine Welt-Koordinate in eine globale Position um
 	 * 
-	 * @param worldPos Welt-Position (wie von Java3D verwendet)
+	 * @param worldPos	Welt-Position (wie von Java3D verwendet)
 	 * @return globale Position (wie zur Lokalisierung verwendet) / Blocks
 	 */
 	public Point2i transformWorldposToGlobalpos(Point3d worldPos) {

--- a/ctSim/model/ParcoursGenerator.java
+++ b/ctSim/model/ParcoursGenerator.java
@@ -24,194 +24,166 @@ import java.util.Random;
 /**
  * Parcours-Generator für den c't-Sim-Wettbewerb
  * 
- * @author pek (pek@heise.de)
+ * @author Peter König (pek@heise.de)
  * 
  */
 
 public class ParcoursGenerator {
 
-	/**
-	 * Zeichen für normalen Boden
-	 */
+	/** Zeichen für normalen Boden */
 	private static final char FLOOR = ' ';
 
-	/**
-	 * Zeichen für hellen Boden
-	 */
+	/** Zeichen für hellen Boden */
 	private static final char WHITE = '.';
 
-	/**
-	 * Zeichen für einzelnes Wandstück
-	 */
+	/** Zeichen für einzelnes Wandstück */
 	private static final char WALL = 'X';
 
-	/**
-	 * Zeichen für horizontales Wandstück
-	 */
+	/** Zeichen für horizontales Wandstück */
 	private static final char WALLH = '=';
 
-	/**
-	 * Zeichen für vertikales Wandstück
-	 */
+	/** Zeichen für vertikales Wandstück */
 	private static final char WALLV = '#';
 
-	/**
-	 * Zeichen für Loch
-	 */
+	/** Zeichen für Loch */
 	private static final char HOLE = 'L';
 
-	/**
-	 * Zeichen für Lampe
-	 */
+	/** Zeichen für Lampe */
 	private static final char LAMP = '*';
 
-	/**
-	 * Zeichen für Zielfeld
-	 */
+	/** Zeichen für Zielfeld */
 	private static final char GOAL = 'Z';
 
-	/**
-	 * Zeichen für linkes Startfeld
-	 */
+	/** Zeichen für linkes Startfeld */
 	private static final char START1 = '1';
 
-	/**
-	 * Zeichen für rechtes Startfeld
-	 */
+	/** Zeichen für rechtes Startfeld */
 	private static final char START2 = '2';
 
-	/**
-	 * XML-String -- Anfang der Parcours-Datei
-	 */
-	private static final String xmlHead = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
-			+ "<!DOCTYPE world SYSTEM \"parcours.dtd\">\n" //$NON-NLS-1$
-			+ "<world>\n" //$NON-NLS-1$
+	/** XML-String -- Anfang der Parcours-Datei */
+	private static final String xmlHead = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"	// $NON-NLS-1$
+			+ "<!DOCTYPE world SYSTEM \"parcours.dtd\">\n"	// $NON-NLS-1$
+			+ "<world>\n"	// $NON-NLS-1$
 			+ "	<description>Dieses ist ein automatisch generierter Beispielparcours für den c't-Sim-Wettbewerb.</description>\n" //$NON-NLS-1$
-			+ "	<parcours>\n"; //$NON-NLS-1$
+			+ "	<parcours>\n";	// $NON-NLS-1$
+
+	/** XML-String -- Ende der Parcours-Datei */
+	private static final String xmlTail = "	</parcours>\n"	// $NON-NLS-1$
+			+ "	<optics>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"X\">\n"	// $NON-NLS-1$
+			+ "			<description>quadratische Wand</description>\n"	// $NON-NLS-1$
+			+ "			<texture>textures/rock_wall.jpg</texture>\n"	// $NON-NLS-1$
+			+ "			<color>#999999</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"#\">\n"	// $NON-NLS-1$
+			+ "			<description>senkrechte Wand</description>\n"	// $NON-NLS-1$
+			+ "			<clone>X</clone>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"=\">\n"	// $NON-NLS-1$
+			+ "			<description>wagrechte Wand</description>\n"	// $NON-NLS-1$
+			+ "			<clone>X</clone>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\".\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden im Eingangsbereich</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#FFFFFF</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#FFFFFF</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\" \">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden im Labyrinth</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#606060</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#606060</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"L\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden mit Loch</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#000000</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#000000</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"1\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden des Startfeldes 1</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#993030</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#993030</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"2\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden des Startfeldes 2</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#000099</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#000099</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"0\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden des Default-Startfeldes</description>\n"	// $NON-NLS-1$
+			+ "			<clone>.</clone>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"Z\">\n"	// $NON-NLS-1$
+			+ "			<description>Fussboden des Zielfeldes 0</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#66FF00</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#66FF00</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"*\"><description>Lichtkugel</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"emmissive\">#FFFF90</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"-\"><description>Linie</description>\n"	// $NON-NLS-1$
+			+ "			<color type=\"ambient\">#000000</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"diffuse\">#000000</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"specular\">#000000</color>\n"	// $NON-NLS-1$
+			+ "			<color type=\"emmissive\">#000000</color>\n"	// $NON-NLS-1$
+			+ "		</appearance>\n"	// $NON-NLS-1$
+			+ "		<appearance type=\"|\"><description>Linie</description>\n"	// $NON-NLS-1$
+			+ "			<clone>-</clone>\n" + "		</appearance>\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "		<appearance type=\"/\">\n"	// $NON-NLS-1$
+			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "		</appearance>\n" + "		<appearance type=\"\\\">\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "		</appearance>\n" + "		<appearance type=\"+\">\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "		</appearance>\n" + "		<appearance type=\"~\">\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n"	// $NON-NLS-1$	// $NON-NLS-2$
+			+ "		</appearance>\n" + "	</optics>\n" + "</world>\n";	// $NON-NLS-1$	// $NON-NLS-2$	// $NON-NLS-3$
 
 	/**
-	 * XML-String -- Ende der Parcours-Datei
-	 */
-	private static final String xmlTail = "	</parcours>\n" //$NON-NLS-1$
-			+ "	<optics>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"X\">\n" //$NON-NLS-1$
-			+ "			<description>quadratische Wand</description>\n" //$NON-NLS-1$
-			+ "			<texture>textures/rock_wall.jpg</texture>\n" //$NON-NLS-1$
-			+ "			<color>#999999</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"#\">\n" //$NON-NLS-1$
-			+ "			<description>senkrechte Wand</description>\n" //$NON-NLS-1$
-			+ "			<clone>X</clone>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"=\">\n" //$NON-NLS-1$
-			+ "			<description>wagrechte Wand</description>\n" //$NON-NLS-1$
-			+ "			<clone>X</clone>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\".\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden im Eingangsbereich</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#FFFFFF</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#FFFFFF</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\" \">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden im Labyrinth</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#606060</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#606060</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"L\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden mit Loch</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#000000</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#000000</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"1\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden des Startfeldes 1</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#993030</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#993030</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"2\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden des Startfeldes 2</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#000099</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#000099</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"0\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden des Default-Startfeldes</description>\n" //$NON-NLS-1$
-			+ "			<clone>.</clone>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"Z\">\n" //$NON-NLS-1$
-			+ "			<description>Fussboden des Zielfeldes 0</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#66FF00</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#66FF00</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"*\"><description>Lichtkugel</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"emmissive\">#FFFF90</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"-\"><description>Linie</description>\n" //$NON-NLS-1$
-			+ "			<color type=\"ambient\">#000000</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"diffuse\">#000000</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"specular\">#000000</color>\n" //$NON-NLS-1$
-			+ "			<color type=\"emmissive\">#000000</color>\n" //$NON-NLS-1$
-			+ "		</appearance>\n" //$NON-NLS-1$
-			+ "		<appearance type=\"|\"><description>Linie</description>\n" //$NON-NLS-1$
-			+ "			<clone>-</clone>\n" + "		</appearance>\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "		<appearance type=\"/\">\n" //$NON-NLS-1$
-			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n" //$NON-NLS-1$//$NON-NLS-2$
-			+ "		</appearance>\n" + "		<appearance type=\"\\\">\n" //$NON-NLS-1$//$NON-NLS-2$
-			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "		</appearance>\n" + "		<appearance type=\"+\">\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "		</appearance>\n" + "		<appearance type=\"~\">\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "			<description>Linie</description>\n" + "			<clone>-</clone>\n" //$NON-NLS-1$ //$NON-NLS-2$
-			+ "		</appearance>\n" + "	</optics>\n" + "</world>\n"; //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
-
-	/**
-	 * Die Karte ist ein char-Array, erste Dimension die Zeilennummer, die
-	 * zweite die Spaltennummer:
+	 * Die Karte ist ein char-Array, erste Dimension die Zeilennummer,
+	 * die Zweite die Spaltennummer:
 	 */
 	private static char[][] map;
 
 	/**
-	 * Die Karte wird allerdings zurerst nur zur Hälfte generiert, ebenfalls
-	 * als char-Array, erste Dimension die Zeilennummer, die zweite die
-	 * Spaltennummer:
+	 * Die Karte wird allerdings zurerst nur zur Hälfte generiert, ebenfalls als
+	 * char-Array, erste Dimension die Zeilennummer, die Zweite die Spaltennummer:
 	 */
 	private static char[][] halfmap;
 
-	/**
-	 * Die Größe des Labyrinths in Feldern; die Breite ist die Breite der
-	 * halben Karte!
+	/** 
+	 * Die Größe des Labyrinths in Feldern;
+	 * die Breite ist die Breite der halben Karte!
 	 */
 	private static int width;
 
-	/**
-	 * Die Höhe:
-	 */
+	/** Die Höhe: */
 	private static int height;
 
-	/**
-	 * Zufallszahlengenerator
-	 */
+	/** Zufallszahlengenerator */
 	private static Random rand;
 
 	/**
-	 * Parameter für die Erzeugung: Verschnoerkelungsfaktor; Anzahl der
-	 * angestrebten Segmente pro Hindernis
+	 * Parameter für die Erzeugung: Verschnörkelungsfaktor;
+	 * Anzahl der angestrebten Segmente pro Hindernis
 	 */
 	private static int twirling;
 
 	/**
-	 * Hindernisdichte an der Wand; klein = rauh Es wird Wandlange/wallRoughness
-	 * oft versucht, der Wand ein Hindernis hinzuzufügen
+	 * Hindernisdichte an der Wand; klein = rauh
+	 * Es wird Wandlänge/wallRoughness oft versucht,
+	 * der Wand ein Hindernis hinzuzufügen.
 	 */
 	private static int wallRoughness;
 
 	/**
-	 * Hindernisdichte im Inneren des Labyrinths klein = viele Es wird
-	 * Wandlange/wallRoughness oft versucht, der Wand ein Hindernis
-	 * hinzuzufügen
+	 * Hindernisdichte im Inneren des Labyrinths klein = viele
+	 * Es wird Wandlänge/wallRoughness oft versucht,
+	 * der Wand ein Hindernis hinzuzufügen
 	 */
 	private static int innerRoughness;
 
 	/**
-	 * Lochanteil; jedes n-te Wandstück wird durch Loch ersetzt
+	 * Lochanteil; jedes n-te Wandstück wird durch ein Loch ersetzt
 	 */
 	private static int perforation;
 
@@ -219,8 +191,7 @@ public class ParcoursGenerator {
 	 * Diese main-Methode dient nur dem Debugging. Sie generiert 20 Parcours mit
 	 * zufälligen Parametern und gibt sie auf der Konsole aus.
 	 * 
-	 * @param args
-	 *            Keine Argumente
+	 * @param args	Keine Argumente
 	 */
 	public static void main(String[] args) {
 		for (int i = 0; i < 20; i++) {
@@ -241,12 +212,12 @@ public class ParcoursGenerator {
 		// Generiere zufällige Werte für die Parameter:
 		int w, h, wr, ir, t, p;
 		rand = new Random();
-		w = rand.nextInt(10) + 6; // Breite zwischen 12 und 30 Felder
-		h = rand.nextInt(19) + 12; // Höhe zwischen 12 und 30 Felder
-		wr = rand.nextInt(5) + 2; // zwischen 2 und 6;
-		ir = rand.nextInt(6) + 7; // zwischen 7 und 12;
-		t = rand.nextInt(4) + 2; // zwischen 2 und 5;
-		p = rand.nextInt(15) + 6; // zwischen 6 und 20;
+		w = rand.nextInt(10) + 6;	// Breite zwischen 12 und 30 Felder
+		h = rand.nextInt(19) + 12;	// Höhe zwischen 12 und 30 Felder
+		wr = rand.nextInt(5) + 2;	// zwischen 2 und 6;
+		ir = rand.nextInt(6) + 7;	// zwischen 7 und 12;
+		t = rand.nextInt(4) + 2;	// zwischen 2 und 5;
+		p = rand.nextInt(15) + 6;	// zwischen 6 und 20;
 		// Rufe Methode mit den Parametern auf:
 		return generateParc(w, h, ir, wr, t, p);
 	}
@@ -254,25 +225,17 @@ public class ParcoursGenerator {
 	/**
 	 * Diese Methode generiert das eigentliche Labyrinth.
 	 * 
-	 * @param wi
-	 *            Halbe Breite des Parcours in Feldern
-	 * @param he
-	 *            Höhe des Parcours in Feldern
-	 * @param wr
-	 *            Hindernisdichte an der Wand; klein = rauh
-	 * @param ir
-	 *            Verhältnis der Hindernismenge an der Wand zu solchen in der
-	 *            Mitte
-	 * @param tw
-	 *            Verschnoerkelungsfaktor; Anzahl der angestrebten Segmente pro
-	 *            Hindernis
-	 * @param pe
-	 *            Lochanteil; jedes n-te Wandstück wird durch Loch ersetzt
+	 * @param wi	Halbe Breite des Parcours in Feldern
+	 * @param he	Höhe des Parcours in Feldern
+	 * @param wr	Hindernisdichte an der Wand; klein = rauh
+	 * @param ir	Verhältnis der Hindernismenge an der Wand zu solchen in der Mitte
+	 * @param tw	Verschnörkelungsfaktor; Anzahl der angestrebten Segmente pro Hindernis
+	 * @param pe	Lochanteil; jedes n-te Wandstück wird durch Loch ersetzt
 	 * @return Der Parcours als XML-String
 	 */
 	public static String generateParc(int wi, int he, int wr, int ir, int tw,
 			int pe) {
-		// Alle Werte sind Größer als 0:
+		// Alle Werte sind größer als 0:
 		width = Math.max(wi, 1);
 		height = Math.max(he, 1);
 		wallRoughness = Math.max(wr, 1);
@@ -283,13 +246,12 @@ public class ParcoursGenerator {
 		/*
 		 * Zunächst wird nur die halbe Karte gebaut.
 		 * 
-		 * Erste Dimension ist die Zeilennummer und zweite die Spaltennummer,
+		 * Erste Dimension ist die Zeilennummer und die Zweite die Spaltennummer,
 		 * daher erst Höhe und dann Breite:
 		 */
-
 		halfmap = new char[height][width];
 
-		// Mit Leerzeichen fuellen:
+		// Mit Leerzeichen füllen:
 		for (int r = 0; r < height; r++) {
 			for (int c = 0; c < width; c++) {
 				halfmap[r][c] = FLOOR;
@@ -312,12 +274,10 @@ public class ParcoursGenerator {
 		return parc2XML(map);
 	}
 
-	/**
-	 * Versieht das Spielfeld mit einer Einfriedung:
-	 */
+	/** Versieht das Spielfeld mit einer Einfriedung: */
 	private static void buildEnclosure() {
 
-		// Nord- und Suedwand:
+		// Nord- und Südwand:
 		for (int c = 1; c < width; c++) {
 			halfmap[0][c] = WALLH;
 			halfmap[height - 1][c] = WALLH;
@@ -338,8 +298,8 @@ public class ParcoursGenerator {
 	}
 
 	/**
-* Fügt Hindernisse an die Wände an, so dass der Weg an der Wand entlang
-	 * auf jeden Fall länger ist als der kuerzeste Weg. Die Methode sorgt auch
+	 * Fügt Hindernisse an die Wände an, so dass der Weg an der Wand entlang
+	 * auf jeden Fall länger ist als der kürzeste Weg. Die Methode sorgt auch
 	 * für Hindernisse, die über die Mittellinie hinausgehen.
 	 */
 	private static void roughenWalls() {
@@ -348,13 +308,13 @@ public class ParcoursGenerator {
 		 * xxxRoughness -- im Osten innerRoughness, sonst wallRoughness
 		 */
 
-		// Zuerst Westwand moeblieren:
+		// Zuerst Westwand möblieren:
 		int obstNum = height / wallRoughness;
 		for (int i = 0; i < obstNum; i++) {
 			addWallObstacle('W');
 		}
 
-		// Dann Nord- und Suedwand moeblieren:
+		// Dann Nord- und Südwand möblieren:
 		obstNum = width / wallRoughness;
 		for (int i = 0; i < obstNum; i++) {
 			addWallObstacle('N');
@@ -362,7 +322,7 @@ public class ParcoursGenerator {
 		}
 
 		/*
-		 * Zuletzt Ostwand moeblieren (= Hindernisse einfügen, die über die
+		 * Zuletzt Ostwand möblieren (= Hindernisse einfügen, die über die
 		 * Mittelline gehen):
 		 */
 		obstNum = height / innerRoughness;
@@ -375,8 +335,7 @@ public class ParcoursGenerator {
 	 * Fügt ein neues Hindernis an einen zufälligen Ort direkt an der
 	 * betreffenden Wand hinzu, sofern dort Platz genug vorhanden ist.
 	 * 
-	 * @param wall
-	 *            Die Wand, die ein Hindernis erhalten soll (N, S, W, E)
+	 * @param wall	Die Wand, die ein Hindernis erhalten soll (N, S, W, E)
 	 */
 	private static void addWallObstacle(char wall) {
 
@@ -386,16 +345,14 @@ public class ParcoursGenerator {
 		case 'N':
 			// erste Zeile,
 			row = 0;
-			// Spalte ist Zufall, hält aber Sicherheitsabstand
-			// von der Ecke und vom Zielfeld:
+			// Spalte ist Zufall, hält aber Sicherheitsabstand von der Ecke und vom Zielfeld:
 			col = rand.nextInt(width - 5) + 3;
 			generateTwirl(row, col, 2, twirling);
 			break;
 		case 'S':
 			// zweite Zeile,
 			row = height - 1;
-			// Spalte ist Zufall, hält aber Sicherheitsabstand
-			// von der Ecke:
+			// Spalte ist Zufall, hält aber Sicherheitsabstand von der Ecke:
 			col = rand.nextInt(width - 4) + 3;
 			generateTwirl(row, col, 0, twirling);
 			break;
@@ -424,49 +381,39 @@ public class ParcoursGenerator {
 	}
 
 	/**
-	 * "Verschnoerkelt" ein Hindernis in zufällige Richtung. Die Methode ruft
-	 * sich rekursiv selbst auf.
+	 * "Verschnörkelt" ein Hindernis in zufällige Richtung.
+	 * Die Methode ruft sich rekursiv selbst auf.
 	 * 
-	 * @param row
-	 *            Zeile der Startkoordinate
-	 * @param col
-	 *            Spalte der Startkoordinate
-	 * 
-	 * @param twirlsLeft
-	 *            Wie viele weitere Segmente (rekursive Methodenaufrufe) noch
-	 *            folgen (duerfen)
+	 * @param row			Zeile der Startkoordinate
+	 * @param col			Spalte der Startkoordinate
+	 * @param twirlsLeft	Wie viele weitere Segmente (rekursive Methodenaufrufe)
+	 * 						noch folgen (dürfen)
 	 */
 
 	private static void generateTwirl(int row, int col, int twirlsLeft) {
 		// Zufällige Richtung: 0 = nach Norden 1 = nach Osten
-		// 2 = nach Sueden 3= nach Westen
+		// 2 = nach Süden 3= nach Westen
 		int dir = rand.nextInt(4);
 		// Dann Methode mit diesen Parametern aufrufen:
 		generateTwirl(row, col, dir, twirlsLeft);
 	}
 
 	/**
-	 * "Verschnoerkelt" ein Hindernis in zufällige Richtung. Die Methode ruft
-	 * sich rekursiv selbst auf.
+	 * "Verschnörkelt" ein Hindernis in zufällige Richtung.
+	 * Die Methode ruft sich rekursiv selbst auf.
 	 * 
-	 * 
-	 * @param row
-	 *            Zeile der Startkoordinate
-	 * @param col
-	 *            Spalte der Startkoordinate
-	 * @param dir
-	 *            Richtung (0=N, 1=O, 2=S, 3=W)
-	 * @param twirlsLeft
-	 *            Wie viele weitere Segmente (rekursive Methodenaufrufe) noch
-	 *            folgen (duerfen)
-	 * 
+	 * @param row			Zeile der Startkoordinate
+	 * @param col			Spalte der Startkoordinate
+	 * @param dir			Richtung (0=N, 1=O, 2=S, 3=W)
+	 * @param twirlsLeft	Wie viele weitere Segmente (rekursive Methodenaufrufe)
+	 * 						noch folgen (dürfen)
 	 */
 	private static void generateTwirl(int row, int col, int dir, int twirlsLeft) {
 		twirlsLeft--;
 		if (twirlsLeft < 0)
 			return;
 		/*
-		 * Der Schnoerkel wird segmentweise gebaut. Segmente haben eine
+		 * Der Schnörkel wird segmentweise gebaut. Segmente haben eine
 		 * zufällig bestimmte Wunschlänge, die mindestens 3 beträgt und auch
 		 * von den Parcours-Dimensionen abhängt:
 		 */
@@ -476,9 +423,8 @@ public class ParcoursGenerator {
 
 		// Falls das nächste Feld in der gewünschten Richtung Boden ist...
 		if (testNextFields(row, col, dir, 1)) {
-			// ... Schnoerkel so lange verlängern, bis nicht mehr
-			// genuegend Raum da ist oder bis die gewünschte Länge
-			// erreicht ist:
+			// ... Schnörkel so lange verlängern, bis nicht mehr genügend Raum da ist
+			// oder bis die gewünschte Länge erreicht ist:
 			while (testNextFields(row, col, dir, 3) && desL > 0) {
 				newC = getNextCoordinate(row, col, dir);
 				if (dir % 2 == 0) {
@@ -490,36 +436,30 @@ public class ParcoursGenerator {
 				col = newC[1];
 				desL--;
 			}
-			// Ansonsten ist dieser Schnoerkelabschnitt zu Ende
-			// und der Nächste beginnt:
-
+			// Ansonsten ist dieser Schnörkelabschnitt zu Ende und der Nächste beginnt:
 			generateTwirl(row, col, twirlsLeft);
 		} else {
-			// Ansonsten wird versucht, je einen Schnoerkel
-			// rechtwinklig dazu anzubringen:
+			// Ansonsten wird versucht, je einen Schnörkel rechtwinklig dazu anzubringen:
 			if (testNextFields(row, col, (dir + 1) % 4, 3)
 					&& testNextFields(row, col, (dir - 1) % 4, 3)) {
 				generateTwirl(row, col, (dir + 1) % 4, twirlsLeft);
 				generateTwirl(row, col, (dir - 1) % 4, twirlsLeft);
 			}
-			// Irgendwann muss jeder Schnoerkel sein Ende haben 8-)
+			// Irgendwann muss jeder Schnörkel sein Ende haben 8-)
 			else
 				return;
 		}
 	}
 
 	/**
-	 * Testet, ob von einem Feld aus nach Norden, Sueden und Westen gesehen in
+	 * Testet, ob von einem Feld aus nach Norden, Süden und Westen gesehen in
 	 * einer bestimmten Tiefe nur Bodenfelder vorkommen. Es wird auch in die
 	 * Breite geprüft: bei Tiefe 1 ist der geprüfte Streifen 1 Feld breit, bei
 	 * 2 3 Felder und bei 3 oder mehr 5 Felder.
 	 * 
-	 * @param row
-	 *            Zeile des Startfelds
-	 * @param col
-	 *            Spalte des Startfelds
-	 * @param depth
-	 *            Suchtiefe in Feldern
+	 * @param row	Zeile des Startfelds
+	 * @param col	Spalte des Startfelds
+	 * @param depth	Suchtiefe in Feldern
 	 * @return true, wenn alle getesteten Felder Bodenfelder sind.
 	 */
 	private static boolean testNextFields(int row, int col, int depth) {
@@ -534,19 +474,14 @@ public class ParcoursGenerator {
 	 * geprüft: bei Tiefe 1 ist der geprüfte Streifen 1 Feld breit, bei 2 3
 	 * Felder und bei 3 oder mehr 5 Felder.
 	 * 
-	 * @param row
-	 *            Zeile des Startfelds
-	 * @param col
-	 *            Spalte des Startfelds
-	 * @param dir
-	 *            Richtung (0=N, 1=O, 2=S, 3 =W)
-	 * @param depth
-	 *            Suchtiefe in Feldern
+	 * @param row	Zeile des Startfelds
+	 * @param col	Spalte des Startfelds
+	 * @param dir	Richtung (0=N, 1=O, 2=S, 3=W)
+	 * @param depth	Suchtiefe in Feldern
 	 * @return true, wenn alle getesteten Felder Bodenfelder sind.
 	 */
 	private static boolean testNextFields(int row, int col, int dir, int depth) {
-		// Offset sind die ebenfalls zu prüfenden Reihen parallel
-		// zu den eigentlichen Feldern
+		// für Offset sind die ebenfalls zu prüfenden Reihen parallel zu den eigentlichen Feldern
 		int offset = Math.max(0, Math.min(depth - 1, 2));
 
 		boolean result = true;
@@ -584,24 +519,20 @@ public class ParcoursGenerator {
 				result = false;
 			}
 		} catch (ArrayIndexOutOfBoundsException e) {
-
 			// Prüfung freier Felder hat Grenzen des Parcours überschritten,
-			// damit ist definitiv nicht genuegend Platz!
+			// damit ist definitiv nicht genügend Platz!
 			result = false;
 		}
 		return result;
 	}
 
 	/**
-	 * Gibt die Koordinaten eines Felds zurück, dass in angegebener Richtung
-	 * vom übergebenen Feld liegt.
+	 * Gibt die Koordinaten eines Felds zurück,
+	 * das in angegebener Richtung vom übergebenen Feld liegt.
 	 * 
-	 * @param row
-	 *            Die Zeile des Ausgangsfelds
-	 * @param col
-	 *            Die Spalte des Ausgangsfelds
-	 * @param dir
-	 *            Richtung (0=N, 1=O, 2=S, 3 =W)
+	 * @param row	Die Zeile des Ausgangsfelds
+	 * @param col	Die Spalte des Ausgangsfelds
+	 * @param dir	Richtung (0=N, 1=O, 2=S, 3=W)
 	 * @return Ein Tupel mit den neuen Koordinaten [Zeile|Spalte]
 	 */
 	private static int[] getNextCoordinate(int row, int col, int dir) {
@@ -644,15 +575,13 @@ public class ParcoursGenerator {
 			col = rand.nextInt(width);
 			// Ist das gefundene Feld leer und von freiem Raum umgeben?
 			if ((halfmap[row][col] == FLOOR) && testNextFields(row, col, 2)) {
-				// Dann einfach mit extra langen Schnoerkeln anfangen,
+				// Dann einfach mit extra langen Schnörkeln anfangen,
 				generateTwirl(row, col, twirling + 3);
 			}
 		}
 	}
 
-	/**
-	 * Fügt die Startfelder hinzu.
-	 */
+	/** Fügt die Startfelder hinzu. */
 	private static void generateStart() {
 		int offset = rand.nextInt(width - 3) + 2;
 		int row = height - 2;
@@ -667,9 +596,7 @@ public class ParcoursGenerator {
 		map[row - 1][2 * width - offset] = FLOOR;
 	}
 
-	/**
-	 * Spiegelt den halben Parcours aus halfmap in map
-	 */
+	/** Spiegelt den halben Parcours aus halfmap in map */
 	private static void mirror() {
 
 		map = new char[height][width * 2];
@@ -682,9 +609,7 @@ public class ParcoursGenerator {
 		}
 	}
 
-	/**
-	 * Ersetzt je nach Faktor perforation jedes n-te Wandfeld durch ein Loch
-	 */
+	/** Ersetzt je nach Faktor perforation jedes n-te Wandfeld durch ein Loch */
 	private static void perforate() {
 		for (int r = 1; r < height - 1; r++) {
 			for (int c = 1; c < width - 1; c++) {
@@ -700,24 +625,19 @@ public class ParcoursGenerator {
 	/**
 	 * Gibt einen Parcours auf der Konsole aus.
 	 * 
-	 * @param step
-	 *            Bezeichnung des Generierungsschrittes für die Fehlersuche
-	 * @param parc
-	 *            Der Parcours
-	 * 
+	 * @param step	Bezeichnung des Generierungsschrittes für die Fehlersuche
+	 * @param parc	Der Parcours
 	 */
 	@SuppressWarnings("unused")
 	private static void printParc(String step, char[][] parc) {
-		System.out.println("\n" + step + "\n"); //$NON-NLS-1$//$NON-NLS-2$
+		System.out.println("\n" + step + "\n");	// $NON-NLS-1$	// $NON-NLS-2$
 		System.out.println(parc2String(parc));
 	}
 
 	/**
 	 * Formatiert einen Parcours für die Ausgabe auf der Konsole.
 	 * 
-	 * @param parc
-	 *            Der Parcours
-	 * 
+	 * @param parc	Der Parcours
 	 * @return Der Ausgabestring
 	 */
 	private static String parc2String(char[][] parc) {
@@ -726,27 +646,26 @@ public class ParcoursGenerator {
 			for (int c = 0; c < parc[r].length; c++) {
 				result.append(parc[r][c]);
 			}
-			result.append("\n"); //$NON-NLS-1$
+			result.append("\n");	// $NON-NLS-1$
 		}
 		return result.toString();
 	}
 
-	/**
+	/** 
 	 * Schreibt einen Parcours in einen XML-String
 	 * 
-	 * @param parc
-	 *            Der Parcours
+	 * @param parc	Der Parcours
 	 * @return Der XML-String
 	 */
 	private static String parc2XML(char[][] parc) {
 		StringBuffer result = new StringBuffer();
 		result.append(xmlHead);
 		for (int r = 0; r < parc.length; r++) {
-			result.append("<line>"); //$NON-NLS-1$
+			result.append("<line>");	// $NON-NLS-1$
 			for (int c = 0; c < parc[r].length; c++) {
 				result.append(parc[r][c]);
 			}
-			result.append("</line>\n"); //$NON-NLS-1$
+			result.append("</line>\n");	// $NON-NLS-1$
 		}
 		result.append(xmlTail);
 		return result.toString();

--- a/ctSim/model/ParcoursLoader.java
+++ b/ctSim/model/ParcoursLoader.java
@@ -80,14 +80,10 @@ public class ParcoursLoader {
 	/** Z-Koorndinate der Lampen */
 	public static final float LIGHTZ = 0.5f;
 
-	/**
-	 * Linienbreite
-	 */
+	/** Linienbreite */
 	public static final float LINEWIDTH = 0.1f;
 
-	/**
-	 * Horizontales Liniensegment
-	 */
+	/** Horizontales Liniensegment */
 	public static final float[] LINE_HORIZ = {
 		-0.5f,	0f - LINEWIDTH/2,0f,
 		0.5f,	0f - LINEWIDTH/2,0f,
@@ -96,9 +92,7 @@ public class ParcoursLoader {
 		-0.5f,	0f - LINEWIDTH/2,0f,
 	};
 	
-	/**
-	 * Vertikales Liniensegment
-	 */
+	/** Vertikales Liniensegment */
 	public static final float[] LINE_VERT = {
 		0f - LINEWIDTH/2,	-0.5f,	0f,	// Start unten links
 		0f + LINEWIDTH/2,	-0.5f,	0f,	// kurze Linie nach rechts
@@ -107,9 +101,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,	0f,	// lange Linie runter
 	};
 
-	/**
-	 * Linie -- Suedostecke
-	 */
+	/** Linie -- Südostecke */
 	public static final float[] LINE_CORNER_SE = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -120,9 +112,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Lange Linie nach unten
 	};
 	
-	/**
-	 * Linie -- Suedwestecke
-	 */
+	/** Linie -- Südwestecke */
 	public static final float[] LINE_CORNER_SW = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -133,9 +123,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Lange Linie nach unten
 	};
 	
-	/**
-	 * Linie -- Nordwestecke
-	 */
+	/** Linie -- Nordwestecke */
 	public static final float[] LINE_CORNER_NW = {
 		-0.5f,				0.0f + LINEWIDTH/2,	0f,	// Start Links oben
 		-0.5f,				0.0f - LINEWIDTH/2,	0f,	// kurze Linie runter
@@ -146,9 +134,7 @@ public class ParcoursLoader {
 		-0.5f,				0.0f + LINEWIDTH/2,	0f,	// Lange Linie nach links
 	};
 
-	/**
-	 * Linie -- Nordostecke
-	 */
+	/** Linie -- Nordostecke */
 	public static final float[] LINE_CORNER_NE = {
 		0f +LINEWIDTH/2 , 0.5f               ,0f,	// Start oben rechts
 		0f -LINEWIDTH/2 , 0.5f               ,0f,	// kurze Linie nach links
@@ -159,9 +145,7 @@ public class ParcoursLoader {
 		0f +LINEWIDTH/2 , 0.5f				 ,0f,	// lange Linie nach oben
 	};
 
-	/**
-	 * X-Kreuzung
-	 */
+	/** X-Kreuzung */
 	public static final float[] LINE_CROSSING_X = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -178,9 +162,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Kreuz schließen zum Ausgangspunkt
 	};
 	
-	/**
-	 * T-Kreuzung, Ausrichtung wie das T selbst, also Linie geht nach unten
-	 */
+	/** T-Kreuzung, Ausrichtung wie das T selbst, also Linie geht nach unten */
 	public static final float[] LINE_CROSSING_T = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -193,9 +175,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// T schließen zum Ausgangspunkt
 	};
 	
-	/**
-	 * gespiegelte T-Kreuzung, Ausrichtung wie gespiegeltes, also Linie geht nach oben
-	 */
+	/** gespiegelte T-Kreuzung, Ausrichtung wie gespiegeltes, also Linie geht nach oben */
 	public static final float[] LINE_CROSSING_T_MIRR = {
 		-0.5f,				0.0f - LINEWIDTH/2,	0f,	// Start Ecke unten links
 		0.5f,				0.0f - LINEWIDTH/2,	0f,	// lange Linie nach rechts
@@ -210,9 +190,7 @@ public class ParcoursLoader {
 
 	};
 	
-	/**
-	 * T-Kreuzung, 90 Grad gedreht entgegen Uhrzeigersinn, also Linie geht nach rechts
-	 */
+	/** T-Kreuzung, 90 Grad gedreht entgegen Uhrzeigersinn, also Linie geht nach rechts */
 	public static final float[] LINE_CROSSING_T_ROT_UNCLOCKWISE = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start Ecke unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -226,9 +204,7 @@ public class ParcoursLoader {
 
 	};
 	
-	/**
-	 * T-Kreuzung, 90 Grad gedreht in Uhrzeigersinn, also Linie geht nach links
-	 */
+	/** T-Kreuzung, 90 Grad gedreht in Uhrzeigersinn, also Linie geht nach links */
 	public static final float[] LINE_CROSSING_T_ROT_CLOCKWISE = {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Start Ecke unten links
 		0f + LINEWIDTH/2,	-0.5f,				0f,	// kurze Linie nach rechts
@@ -241,10 +217,7 @@ public class ParcoursLoader {
 		0f - LINEWIDTH/2,	-0.5f,				0f,	// Linie runter zum Ausgangspunkt
 	};
 	
-	/**
-	 * Linie -- mit Unterbrechung vertikal
-	 * besteht aus 2 untereinander liegenden Teillinien
-	 */
+	/** Linie -- mit Unterbrechung vertikal besteht aus 2 untereinander liegenden Teillinien */
 	public static final float[] LINE_BREAK_VERT = {
 		0f +LINEWIDTH/2 , 0.5f               ,0f,	// Start oben rechts
 		0f -LINEWIDTH/2 , 0.5f               ,0f,	// kurze Linie nach links
@@ -259,10 +232,7 @@ public class ParcoursLoader {
 		0f +LINEWIDTH/2 , 0.0f - LINEWIDTH/2 ,0f,	// Linie wieder hoch bis unterhalb Mitte
 	};
 	
-	/**
-	 * Linie -- mit Unterbrechung horizontal
-	 * besteht aus 2 nebeneinander liegenden Teillinien
-	 */ 
+	/** Linie -- mit Unterbrechung horizontal besteht aus 2 nebeneinander liegenden Teillinien */ 
 	public static final float[] LINE_BREAK_HOR = {
 		-0.5f           , 0.0f + LINEWIDTH/2 ,0f,	// Start links oberhalb Mitte 
 		-0.5f           , 0.0f - LINEWIDTH/2 ,0f,	// kurze Linie links runter
@@ -289,9 +259,7 @@ public class ParcoursLoader {
 	/** Der eigentliche Parcours */
 	private Parcours parcours;
 
-	/**
-	 * Neuen ParcoursLoader instantiieren
-	 */
+	/** Neuen ParcoursLoader instantiieren */
 	public ParcoursLoader() {
 		super();
 		parcours = new Parcours(this);
@@ -301,16 +269,11 @@ public class ParcoursLoader {
 	 * Erzeugt ein Wandsegment Alle Postionen sind keine Weltkoordinaten,
 	 * sondern ganzen Einheiten, wie sie aus dem ASCII-File kommen
 	 * 
-	 * @param x
-	 *            Position in X-Richtung
-	 * @param y
-	 *            Position in X-Richtung
-	 * @param lengthX
-	 *            Länge der Wand in X-Richtung
-	 * @param lengthY
-	 *            Länge der Wand in Y-Richtung
-	 * @param appearance
-	 *            Die Appearance
+	 * @param x				Position in X-Richtung
+	 * @param y				Position in X-Richtung
+	 * @param lengthX		Länge der Wand in X-Richtung
+	 * @param lengthY		Länge der Wand in Y-Richtung
+	 * @param appearance	Die Appearance
 	 */
 	private void createWall(int x, int y, int lengthX, int lengthY, Appearance appearance) {
 		Box box = new Box(parcours.getBlockSizeInM() / 2 * lengthX, parcours.getBlockSizeInM() / 2 * lengthY, WALL_HEIGHT, appearance);
@@ -321,16 +284,11 @@ public class ParcoursLoader {
 	 * Erzeugt ein Stück Fussboden Alle Postionen sind keine Weltkoordinaten,
 	 * sondern ganzen Einheiten, wie sie aus dem ASCII-File kommen
 	 * 
-	 * @param x
-	 *            Position in X-Richtung
-	 * @param y
-	 *            Position in X-Richtung
-	 * @param lengthX
-	 *            Länge der Fläche in X-Richtung
-	 * @param lengthY
-	 *            Länge der Fläche in Y-Richtung
-	 * @param app
-	 *            Aussehen des Bodens
+	 * @param x			Position in X-Richtung
+	 * @param y			Position in X-Richtung
+	 * @param lengthX	Länge der Fläche in X-Richtung
+	 * @param lengthY	Länge der Fläche in Y-Richtung
+	 * @param app		Aussehen des Bodens
 	 */
 	@SuppressWarnings("unused")
 	private void createFloor(int x, int y, int lengthX, int lengthY, Appearance app) {
@@ -342,12 +300,9 @@ public class ParcoursLoader {
 	 * Erzeugt ein Stück Fussboden Alle Postionen sind keine Weltkoordinaten,
 	 * sondern ganzen Einheiten, wie sie aus dem ASCII-File kommen
 	 * 
-	 * @param x
-	 *            Position in X-Richtung
-	 * @param y
-	 *            Position in Y-Richtung
-	 * @param app
-	 *            Aussehen des Bodens
+	 * @param x		Position in X-Richtung
+	 * @param y		Position in Y-Richtung
+	 * @param app	Aussehen des Bodens
 	 */
 	private void createFloor(int x, int y, Appearance app) {
 		Box box = new Box(parcours.getBlockSizeInM() * 0.5f, parcours.getBlockSizeInM() * 0.5f, World.PLAYGROUND_THICKNESS, app);
@@ -359,8 +314,7 @@ public class ParcoursLoader {
 	 * Weltkoordinaten, sondern ganzen Einheiten, wie sie aus dem ASCII-File
 	 * kommen
 	 * 
-	 * @param app
-	 *            Aussehen des Bodens
+	 * @param app	Aussehen des Bodens
 	 */
 	private void createWholeFloor(Appearance app) {
 		Box box = new Box(parcours.getWidthInBlocks() * parcours.getBlockSizeInM() * 0.5f,
@@ -375,14 +329,10 @@ public class ParcoursLoader {
 	 * Weltkoordinaten, sondern ganzen Einheiten, wie sie aus dem ASCII-File
 	 * kommen
 	 * 
-	 * @param x
-	 *            Position in X-Richtung
-	 * @param y
-	 *            Position in Y-Richtung
-	 * @param points
-	 *            Punkte der Linie
-	 * @param appearance
-	 *            Art der Linie
+	 * @param x				Position in X-Richtung
+	 * @param y				Position in Y-Richtung
+	 * @param points		Punkte der Linie
+	 * @param appearance	Art der Linie
 	 */
 	private void createLine(int x, int y, float[] points, Appearance appearance) {
 		// zwei Polygone (Deckel und Boden) mit N Ecken
@@ -423,10 +373,10 @@ public class ParcoursLoader {
 	/**
 	 * Erzeugt eine Säule, auch mit Lichtquelle obendrauf möglich
 	 * 
-	 * @param x			X-Koordinate (bewegliches Objekt) oder X-Achse im Parcours (unbewegliches Objekt)
-	 * @param y			Y-Koordinate (bewegliches Objekt) oder Y-Achse im Parcours (unbewegliches Objekt)
-	 * @param diameter	Durchmesser der Säule
-	 * @param height	Höhe der Säule
+	 * @param x					X-Koordinate (bewegliches Objekt) oder X-Achse im Parcours (unbewegliches Objekt)
+	 * @param y					Y-Koordinate (bewegliches Objekt) oder Y-Achse im Parcours (unbewegliches Objekt)
+	 * @param diameter			Durchmesser der Säule
+	 * @param height			Höhe der Säule
 	 * @param bodyAppearance	Säulen-Appearance
 	 * @param lightAppearance	Licht-Appearance oder null
 	 * @param moveable			Soll das Objekt bewegbar sein?
@@ -462,24 +412,22 @@ public class ParcoursLoader {
 	
 	/**
 	 * Erzeugt ein bewegliches Objekt
-	 * @param x X-Koordinate
-	 * @param y Y-Koordinate
+	 * 
+	 * @param x	X-Koordinate
+	 * @param y	Y-Koordinate
 	 */
 	public void createMovableObject(float x, float y) {
 		createPillar(x, y, 0.03f, 0.08f, getAppearance('o'), null, true);
 	}
 
 	/**
-* Fügt ein Licht ein
+	 * Fügt ein Licht ein
 	 * 
 	 * @param pointLightBounds
 	 * @param pointLightColor
-	 * @param x
-	 *            X-Koordinate
-	 * @param y
-	 *            Y-Koordinate
-	 * @param appearance
-	 *            Die Appearance
+	 * @param x					X-Koordinate
+	 * @param y					Y-Koordinate
+	 * @param appearance		Die Appearance
 	 */
 	private void createLight(BoundingSphere pointLightBounds, Color3f pointLightColor, int x, int y, Appearance appearance) {
 		// Lichter bestehen aus dem echten Licht
@@ -498,10 +446,11 @@ public class ParcoursLoader {
 	}
 	
 	/**
-* Fügt eine BPS-Landmarke ein
-	 * @param x X-Koordinate [Parcours-Block]
-	 * @param y Y-Koordinate [Parcours-Block]
-	 * @param appearance Die Appearance
+	 * Fügt eine BPS-Landmarke ein
+	 * 
+	 * @param x				X-Koordinate [Parcours-Block]
+	 * @param y				Y-Koordinate [Parcours-Block]
+	 * @param appearance	Die Appearance
 	 */
 	private void createBPSBeacon(int x, int y, Appearance appearance) {
 		PointLight pointBPSLight = new PointLight();
@@ -522,13 +471,9 @@ public class ParcoursLoader {
 	 * Prüft die angrenzenden Felder (ohne diagonalen), ob mindestens eines
 	 * davon den übergebenen Wert hat
 	 * 
-	 * @param x
-	 *            X-Koordinate des mittelfeldes
-	 * @param y
-	 *            Y-Koordinate des mittelfeldes
-	 * @param c
-	 *            Der zu suchende Feldtyp
-	 * 
+	 * @param x	X-Koordinate des mittelfeldes
+	 * @param y	Y-Koordinate des mittelfeldes
+	 * @param c	Der zu suchende Feldtyp
 	 * @return -1 wenn kein Feld den Wert hat. Wenn er einen Nachbarn findet
 	 *         dann die Richtung in Grad. 0 = (x=1, y=0) ab da im Uhrzeigersinn
 	 */
@@ -549,9 +494,7 @@ public class ParcoursLoader {
 		return -1;
 	}
 
-	/**
-	 * Liest die parcourMap ein und baut daraus einen Parcour zusammen
-	 */
+	/** Liest die parcourMap ein und baut daraus einen Parcour zusammen */
 	public void parse() {
 		int l;
 		int d;
@@ -568,8 +511,8 @@ public class ParcoursLoader {
 						d = x;
 						// ermittle die Länge der zusammenhängenden Wand
 						while ((d < parcours.getWidthInBlocks()) && (parcoursMap[d][y] == '=')) {
-							parcoursMap[d][y] = 'O'; // Feld ist schon bearbeitet
-							l++; // Länge hochzählen
+							parcoursMap[d][y] = 'O';	// Feld ist schon bearbeitet
+							l++;	// Länge hochzählen
 							d++;
 						}
 						createWall(x, y, l, 1, getAppearance('='));
@@ -579,13 +522,13 @@ public class ParcoursLoader {
 						d = y;
 						// ermittle die Länge der zusammenhängenden Wand
 						while ((d < parcours.getHeightInBlocks()) && (parcoursMap[x][d] == '#')) {
-							parcoursMap[x][d] = 'O'; // Feld ist schon bearbeitet
-							l++; // Länge hochzählen
+							parcoursMap[x][d] = 'O';	// Feld ist schon bearbeitet
+							l++;	// Länge hochzählen
 							d++;
 						}
 						createWall(x, y, 1, l, getAppearance('#'));
 						break;
-					case '*': // Licht
+					case '*':	// Licht
 						createPillar(x, y, 0.1f, LIGHTZ, getAppearance('X'), getAppearance('*'), false);
 						// sind wir im Startbereich ?
 						if (checkNeighbours(x, y, '.') != -1) {
@@ -594,10 +537,10 @@ public class ParcoursLoader {
 							createFloor(x, y, getAppearance(' '));
 						}
 						break;
-					case 'o': // bewegliches Objekt
+					case 'o':	// bewegliches Objekt
 						createMovableObject((x + 0.5f) * parcours.getBlockSizeInM(), (y + 0.5f) * parcours.getBlockSizeInM());
 						break;
-					case 'l': // Landmarke
+					case 'l':	// Landmarke
 //						if (Beacon.checkParcoursPosition(this.parcours, x, y)) {
 							createBPSBeacon(x, y, getAppearance('l'));
 //						} else {
@@ -684,20 +627,21 @@ public class ParcoursLoader {
 			
 			// Hat mit dem Einzeichnen des Wegs bis zum Ziel zu tun; sollte
 			// ordentlich integriert werden: Menüeintrag in GUI, der das
-			// Einzeichnen ein-/ausschaltet. Aus Gruenden der Klarheit sollten
+			// Einzeichnen ein-/ausschaltet. Aus Gründen der Klarheit sollten
 			// die Linien vorher ihre eigene BranchGroup bekommen
+			
 			/*
 			 * for (int i=0; i<Parcours.BOTS; i++){ double dist=
 			 * this.parcours.getShortestDistanceToFinish
 			 * (this.parcours.getStartPosition(i));
 			 * 
 			 * if (dist>=0)
-			 * System.out.println("Distanz zum Ziel von Starpunkt "+
+			 * System.out.println("Distanz zum Ziel von Startpunkt "+
 			 * i+" = "+dist+" m"); else
-			 * System.out.println("Kein Weg zum Ziel von Starpunkt "+i);
+			 * System.out.println("Kein Weg zum Ziel von Startpunkt "+i);
 			 * 
 			 * 
-			 * // finde die kuerzeste Verbindung Vector<TurningPoint>
+			 * // finde die kürzeste Verbindung Vector<TurningPoint>
 			 * shortestPath=
 			 * this.parcours.getShortestPath(this.parcours.getStartPosition(i));
 			 * 
@@ -721,30 +665,26 @@ public class ParcoursLoader {
 	 * Lädt einen Parcours aus einer InputSource.
 	 * 
 	 * @param source
-	 *            Xerces-InputSource-Objekt, aus dem der Parcours geholt werden
-	 *            kann. Der Sinn ist, dass beliebige Eingabequellen
-	 *            übergeben werden können und daher nicht mehr nur aus
-	 *            Dateien, sondern auch aus Strings oder von sonstwo gelesen
-	 *            werden kann.
-	 *            </p>
+	 *            Xerces-InputSource-Objekt, aus dem der Parcours geholt werden kann.
+	 *            Der Sinn ist, dass beliebige Eingabequellen übergeben werden können
+	 *            und daher nicht mehr nur aus Dateien, sondern auch aus Strings oder
+	 *            von sonstwo gelesen werden kann.</p>
 	 * 
 	 * @param resolver
-	 *            Der zu verwendende Xerces-EntityResolver, oder
-	 *            <code>null</code>, wenn der Standard-Resolver verwendet werden
-	 *            soll. Der DocumentBuilder, der dieser Methode zugrundeliegt,
-	 *            verwendet den Resolver während dem Verarbeiten der im XML
-	 *            vorkommenden "system identifier" und "public identifier".
-	 *            Diese treten in unseren Parcoursdateien nur an einer Stelle
-	 *            auf, nämlich in Zeile&nbsp;2:
-	 *            <code>&lt;!DOCTYPE collection SYSTEM "parcours.dtd"></code>.
+	 *            Der zu verwendende Xerces-EntityResolver, oder <code>null</code>,
+	 *            wenn der Standard-Resolver verwendet werden soll. Der DocumentBuilder,
+	 *            der dieser Methode zugrundeliegt, verwendet den Resolver während dem
+	 *            Verarbeiten der im XML vorkommenden "system identifier" und
+	 *            "public identifier". Diese treten in unseren Parcoursdateien nur an
+	 *            einer Stelle auf, nämlich in Zeile 2:
+	 *            <code><!DOCTYPE collection SYSTEM "parcours.dtd"></code>.
 	 *            Der system identifier ist dabei <code>parcours.dtd</code>.
-	 *            Für Parcours-Dateien ist kein Resolver nötig (= es
-	 *            kann <code>null</code> übergeben werden), weil sie im
-	 *            gleichen Verzeichnis liegen wie die Datei parcours.dtd.
-	 *            Für Parcours, die aus XML-Strings gelesen werden, ist ein
-	 *            Resolver nötig, da der Parser sonst nur im
-	 *            ctSim-Verzeichnis sucht (nicht im Verzeichnis ctSim/parcours),
-	 *            und daher die Datei ctSim/parcours/parcours.dtd nicht findet.
+	 *            Für Parcours-Dateien ist kein Resolver nötig (= es kann <code>null</code>
+	 *            übergeben werden), weil sie im gleichen Verzeichnis liegen wie die Datei
+	 *            parcours.dtd. Für Parcours, die aus XML-Strings gelesen werden, ist ein
+	 *            Resolver nötig, da der Parser sonst nur im ctSim-Verzeichnis sucht (nicht
+	 *            im Verzeichnis ctSim/parcours), und daher die Datei ctSim/parcours/parcours.dtd
+	 *            nicht findet.
 	 * 
 	 * @throws SAXException
 	 * @throws IOException
@@ -763,17 +703,17 @@ public class ParcoursLoader {
 			// einlesen und umwandeln in ein Document
 			Document doc = builder.parse(source);
 
-			// Und anfangen mit dem abarbeiten
+			// Und anfangen mit dem Abarbeiten
 
-			// als erster suchen wir uns den Parcours-Block
+			// als erstes suchen wir uns den Parcours-Block
 			Node n = doc.getDocumentElement().getFirstChild();
 			while ((n != null) && (!n.getNodeName().equals("parcours"))) {
 				n = n.getNextSibling();
 			}
 			// jetzt haben wir ihn
 
-			int y = 0; // Anzahl der Zeilen im File
-			int x = 0; // Anzahl der Spalten im File
+			int y = 0;	// Anzahl der Zeilen im File
+			int x = 0;	// Anzahl der Spalten im File
 
 			// Eine Liste aller Kinder des Parcours-Eitnrags organsisieren
 			if (n == null) {
@@ -781,7 +721,7 @@ public class ParcoursLoader {
 			}
 			NodeList children = n.getChildNodes();
 
-			// Anzahl der Zeilen und spalten bestimmen
+			// Anzahl der Zeilen und Spalten bestimmen
 			for (int i = 0; i < children.getLength(); i++) {
 				Node child = children.item(i);
 				if (child.getNodeName().equals("line")) {
@@ -815,14 +755,14 @@ public class ParcoursLoader {
 				}
 			}
 
-			// ********** Appearances aus dem Document lesen
+			// *** Appearances aus dem Document lesen ***
 
-			// suchen wir uns den Otptics-Block
+			// suchen wir uns den Otptics-Block ...
 			n = doc.getDocumentElement().getFirstChild();
 			while ((n != null) && (!n.getNodeName().equals("optics"))) {
 				n = n.getNextSibling();
 			}
-			// jetzt haben wir ihn
+			// ... jetzt haben wir ihn
 
 			// Eine Liste aller Kinder des Parcours-Eintrags organsisieren
 			if (n == null) {
@@ -860,8 +800,8 @@ public class ParcoursLoader {
 				}
 			}
 
-			// Soweit fertig.
-			parse(); // Parcours Zusammenbauen
+			// Soweit fertig...
+			parse();	// Parcours zusammenbauen
 
 		} catch (SAXException e) {
 			lg.warn(e, "Probleme beim Parsen des XML");
@@ -878,8 +818,7 @@ public class ParcoursLoader {
 	/**
 	 * Liefert eine Appearance aus der Liste zurück
 	 * 
-	 * @param key
-	 *            Der Schlüssel, mit dem sie abgelegt wurde
+	 * @param key	Der Schlüssel, mit dem sie abgelegt wurde
 	 * @return Die Appearance
 	 */
 	private Appearance getAppearance(int key) {
@@ -891,17 +830,12 @@ public class ParcoursLoader {
 	}
 
 	/**
-* Fügt die der Liste hinzu
+	 * Fügt die der Liste hinzu
 
-	 * @param item
-	 *            Der Key, iunter dem diese Apperance abgelegt wird
-	 * @param colors
-	 *            HashMap mit je Farbtyp und ASCII-Represenation der Farbe
-	 * @param textureFile
-	 *            Der Name des Texture-Files
-	 * @param clone
-	 *            Referenz auf einen schon bestehenden Eintrag, der geclonet
-	 *            werden soll
+	 * @param item			Der Key, iunter dem diese Apperance abgelegt wird
+	 * @param colors		HashMap mit je Farbtyp und ASCII-Represenation der Farbe
+	 * @param textureFile	Der Name des Texture-Files
+	 * @param clone			Referenz auf einen schon bestehenden Eintrag, der geclonet werden soll
 	 */
 	private void addAppearance(char item, HashMap colors, String textureFile, String clone) {
 		if (clone != null) {
@@ -967,10 +901,8 @@ public class ParcoursLoader {
 	/**
 	 * Debug-Methode
 	 * 
-	 * @param node
-	 *            Node
-	 * @param out
-	 *            Output-Stream
+	 * @param node	Node
+	 * @param out	Output-Stream
 	 */
 	static void print(Node node, PrintStream out) {
 		int type = node.getNodeType();

--- a/ctSim/model/SimulatorFactory.java
+++ b/ctSim/model/SimulatorFactory.java
@@ -25,22 +25,22 @@ import ctSim.model.bots.ctbot.CtBotSimTest;
 import ctSim.model.bots.ctbot.MasterSimulator;
 
 /**
- * Erzeugt einen Simulator für einen Bot, der zu einer Welt gehört und eine 3D-Darstellung besitzt 
+ * Erzeugt einen Simulator für einen Bot, der zu einer Welt gehört
+ * und eine 3D-Darstellung besitzt 
  */
 public abstract class SimulatorFactory {
-	/**
-	 * SimulatorFactory
-	 */
+	/** SimulatorFactory */
 	private SimulatorFactory() {
 		// No-op
 	}
 
 	/**
 	 * Erstellt einen neuen Simulator
+	 * 
 	 * @param world			Welt, zu der der Bot gehört
 	 * @param botWrapper	3D-Darstellung des Bots
 	 * @param bot			Bot-Instanz, die simuliert werden soll
-	 * @return				Simulator für Bot bot
+	 * @return Simulator für Bot bot
 	 */
 	public static Runnable createFor(World world, ThreeDBot botWrapper,	SimulatedBot bot) {
 		/* ct-Bot per TCP-Verbindung (C-Binary) */

--- a/ctSim/model/ThreeDBot.java
+++ b/ctSim/model/ThreeDBot.java
@@ -16,6 +16,7 @@
  * MA 02111-1307, USA.
  *
  */
+
 package ctSim.model;
 
 import static ctSim.model.ThreeDBot.Coord.X;
@@ -61,30 +62,29 @@ import ctSim.util.Misc;
 
 /**
  * <p>
- * Klasse für alle Bots, die eine 3D-Darstellung haben (= simulierte Bots, für
- * reale ist das unnötig). Fungiert als Wrapper um eine {@link SimulatedBot}-Instanz,
- * d.h. diese Klasse hat eine Referenz auf einen {@code SimulatedBot} und ist
- * selbst ein Bot.
+ * Klasse für alle Bots, die eine 3D-Darstellung haben (= simulierte Bots, für reale
+ * Bots ist das unnötig). Fungiert als Wrapper um eine {@link SimulatedBot}-Instanz,
+ * d.h. diese Klasse hat eine Referenz auf einen {@code SimulatedBot} und ist selbst
+ * ein Bot.
  * </p>
  * <p>
  * Die beiden Methoden, die für die Simulation zentral sind:
  * <ul>
- * <li>{@link #run()}, die als eigener Thread läuft. Sie macht periodisch zwei
- * Dinge: Warten und dem SimulatedBot sagen "jetzt Simschritt machen" (für den
- * {@link CtBotSimTcp} heisst das er überträgt Sensordaten, wartet auf Antwort
- * vom C-Code, und aktualisiert dann die Aktuatoren wie vom C-Code gewünscht)</li>
- * <li>{@link #updateSimulation(long)}, die von aussen aufgerufen wird. Die
- * Methode betrachtet die Aktuator-Werte (z.B. Motorgeschwindigkeit) und nimmt
- * an der Simulation die relevanten Änderungen vor (im Beispiel: eine
- * Positions-/Drehungsänderung). Ausserhalb dieser Klasse wird sichergestellt,
- * dass {@code updateSimulation()} immer dann aufgerufen wird, wenn der Thread
- * dieser Klasse gerade wartet, nicht wenn er gerade einen Simschritt macht.
+ * <li>{@link #run()}, die als eigener Thread läuft. Sie macht periodisch zwei Dinge: 
+ * Warten und dem SimulatedBot sagen "jetzt Simschritt machen" (für den {@link CtBotSimTcp}
+ * heißt das er überträgt Sensordaten, wartet auf Antwort vom C-Code, und aktualisiert dann
+ * die Aktuatoren wie vom C-Code gewünscht) {@link #updateSimulation(long)}, die von außen
+ * aufgerufen wird. Die Methode betrachtet die Aktuator-Werte (z.B. Motorgeschwindigkeit)
+ * und nimmt an der Simulation die relevanten Änderungen vor (im Beispiel: eine
+ * Positions-/Drehungsänderung). Außerhalb dieser Klasse wird sichergestellt,
+ * dass {@code updateSimulation()} immer dann aufgerufen wird, wenn der Thread dieser Klasse
+ * gerade wartet, nicht wenn er gerade einen Simschritt macht.
  * </li>
  * </ul>
  * </p>
  *
  * @author Benjamin Benz (bbe@ctmagazin.de)
- * @author Hendrik Krauß &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * @author Hendrik Krauß (hkr@heise.de)
  */
 public class ThreeDBot extends BasicBot implements Runnable {
 	/** Logger */
@@ -93,9 +93,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	/** Liste aller Appearance-Listener */
 	private final List<Runnable1<Color>> appearanceListeners = Misc.newList();
 
-	/**
-	 * Bot-Status
-	 */
+	/** Bot-Status */
 	public enum State {
 		/** Der Bot ist kollidiert (mit der Wand oder mit einem anderen Bot) */
 		COLLIDED(0x001, "collision",
@@ -111,9 +109,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 			"hat keinen Boden mehr unter den Füßen",
 			"hat wieder Boden unter den Füßen"),
 			
-		/**
-		 * Klappenzustand des Bots
-		 */
+		/** Klappenzustand des Bots */
 		DOOR_OPEN(0x003, "door_open",
 			"Klappe ist nun geoeffnet",
 			"Klappe ist nun geschlossen"),
@@ -122,8 +118,8 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		 * Der Bot ist von der weiteren Simulation ausgeschlossen, d.h. seine
 		 * work()-Methode wird nicht mehr aufgerufen. Es steht damit nur noch
 		 * rum, bis die Simulation irgendwann endet. Dieser Zustand kann
-		 * eintreten, wenn die TCP-Verbindung abreißt (Bot-Code
-		 * abgestuerzt) oder ein anderer I/O-Fehler auftritt.
+		 * eintreten, wenn die TCP-Verbindung abreißt (Bot-Code abgestürzt)
+		 * oder ein anderer I/O-Fehler auftritt.
 		 */
 		HALTED(0x100, "halted",
 			"wird aus der Simulation ausgeschlossen");
@@ -139,6 +135,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 		/**
 		 * Bot-Status
+		 * 
 		 * @param legacyValue
 		 * @param appearanceKeyInXml
 		 * @param messageOnEnter
@@ -149,6 +146,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 		/**
 		 * Bot-Status
+		 * 
 		 * @param legacyValue
 		 * @param appearanceKeyInXml
 		 * @param messageOnEnter
@@ -162,9 +160,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		}
 	}
 
-	/**
-	 * 3D-Koordinaten eines Bots
-	 */
+	/** 3D-Koordinaten eines Bots */
 	enum Coord { 
 		/** X-Anteil */
 		X,
@@ -174,22 +170,21 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		Z 
 	}
 
-	/**
-	 * Positionskomponente für 3D-Bots 
-	 */
+	/** Positionskomponente für 3D-Bots */
 	public class PositionCompnt extends BotComponent<SpinnerNumberModel> {
 		/** Koordinaten */
 		private final Coord coord;
 
 		/**
 		 * Erzeugt eine neue Position
+		 * 
 		 * @param coord	Koordinaten
 		 */
 		public PositionCompnt(final Coord coord) {
 			super(new SpinnerNumberModel());
 			this.coord = coord;
 
-			updateExternalModel(); // Initialen Wert setzen
+			updateExternalModel();	// Initialen Wert setzen
 			getExternalModel().addChangeListener(new ChangeListener() {
 				public void stateChanged(ChangeEvent e) {
 					double newValue = getExternalModel().getNumber().doubleValue();
@@ -244,15 +239,14 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		}
 	}
 	
-	/**
-	 * Globalen Bot-Position (wie für Lokalisierung verwendet)
-	 */
+	/** Globale Bot-Position (wie für Lokalisierung verwendet) */
 	public class PositionGlobal extends BotComponent<SpinnerNumberModel> {
 		/** Koordinaten */
 		private final Coord coord;
 		
 		/**
 		 * Erzeugt eine neue Position
+		 * 
 		 * @param coord	Koordinaten
 		 */
 		public PositionGlobal(final Coord coord) {
@@ -300,20 +294,16 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		}
 	}
 
-	/**
-	 * Blickrichtung eines 3D-Bots
-	 */
+	/** Blickrichtung eines 3D-Bots */
 	public class HeadingCompnt extends BotComponent<SpinnerNumberModel> {
 		/** Flag für Status-Änderung ignorieren */
 		protected boolean ignoreStateChange = false;
 
-		/**
-		 * Erzeugt eine neue Blickrichtung für einen 3D-Bot
-		 */
+		/** Erzeugt eine neue Blickrichtung für einen 3D-Bot */
 		public HeadingCompnt() {
 			super(new SpinnerNumberModel());
 
-			updateExternalModel(); // Initialen Wert setzen
+			updateExternalModel();	// Initialen Wert setzen
 			getExternalModel().addChangeListener(new ChangeListener() {
 				public void stateChanged(ChangeEvent e) {
 					/*
@@ -324,7 +314,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 					 * (Vector3d, double), funktioniert die Erkennung nicht gut.
 					 * Daher braucht wir ignoreStateChange. Wenn Heading mal
 					 * komplett auf double umgestellt ist, ist ignoreStateChange
-					 * überflüssig
+					 * überflüssig.
 					 */
 					if (ignoreStateChange) {
 						return;
@@ -375,16 +365,12 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		}
 	}
 	
-	/**
-	 * Globale Blickrichtung (wie für Lokalisierung verwendet)
-	 */
+	/** Globale Blickrichtung (wie für Lokalisierung verwendet) */
 	public class HeadingGlobal extends BotComponent<SpinnerNumberModel> {
-		/**
-		 * Erzeugt eine neue Blickrichtung für einen 3D-Bot
-		 */
+		/** Erzeugt eine neue Blickrichtung für einen 3D-Bot */
 		public HeadingGlobal() {
 			super(new SpinnerNumberModel());
-			updateExternalModel(); // Initialen Wert setzen
+			updateExternalModel();	// Initialen Wert setzen
 		}
 
 		/**
@@ -425,7 +411,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		}
 	}
 
-	/** Bot-Stati */
+	/** Bot-State */
 	private final EnumSet<State> obstState = EnumSet.noneOf(State.class);
 
 	/** Position */
@@ -489,10 +475,10 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	private Runnable simulator;
 
 	/**
-	 * @param posInWorldCoord Position des Objekts
-	 * @param headInWorldCoord Blickrichtung des Objekts
-	 * @param barrier 	Barrier für den neuen Bot
-	 * @param bot		Zugehöriger Bot 
+	 * @param posInWorldCoord	Position des Objekts
+	 * @param headInWorldCoord	Blickrichtung des Objekts
+	 * @param barrier			Barrier für den neuen Bot
+	 * @param bot				Zugehöriger Bot 
 	 */
 	public ThreeDBot(Point3d posInWorldCoord, Vector3d headInWorldCoord, BotBarrier barrier, SimulatedBot bot) {
 		super(bot.toString());
@@ -508,7 +494,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		transformgrp.setCapability(Group.ALLOW_CHILDREN_WRITE);
 		transformgrp.setCapability(Group.ALLOW_CHILDREN_EXTEND);
 
-		/* jetzt wird noch alles nett verpackt */
+		/* ...jetzt wird noch alles nett verpackt */
 		branchgrp = new BranchGroup();
 		branchgrp.setCapability(BranchGroup.ALLOW_DETACH);
 		branchgrp.setCapability(Group.ALLOW_CHILDREN_WRITE);
@@ -530,8 +516,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		setHeading(headInWorldCoord);
 		updateAppearance();
 
-		// Die holen sich die Position in ihren Konstruktoren, daher muss die
-		// schon gesetzt sein
+		// Diese holen sich die Position in ihren Konstruktoren, daher muss jene schon gesetzt sein
 		components.add(new PositionCompnt(X), new PositionCompnt(Y), new PositionCompnt(Z), new HeadingCompnt());
 		
 		if (Config.getValue("BPSSensor").equals("true")) {
@@ -549,6 +534,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	
 	/**
 	 * Setzt den Simulator des Bots
+	 * 
 	 * @param simulator	Simulator
 	 */
 	public void setSimulator(Runnable simulator) {
@@ -564,7 +550,8 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Liefert die BranchGroup
-	 * @return	BG
+	 * 
+	 * @return BG
 	 */
 	public final BranchGroup getBranchGroup() {
 		return branchgrp;
@@ -598,8 +585,9 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	
 	/**
 	 * Zeichnet eine Kugel zu Debug-Zwecken, indem sie zu TestBG hinzugefügt wird
-	 * @param radius Radius der Kugel
-	 * @param transform Transformation, die auf die Box angewendet werden soll
+	 * 
+	 * @param radius	Radius der Kugel
+	 * @param transform	Transformation, die auf die Box angewendet werden soll
 	 */
 	public void showDebugSphere(final double radius, Transform3D transform) {
 		final Sphere sphare = new Sphere((float) radius);
@@ -614,11 +602,12 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Zeichnet eine Box zu Debug-Zwecken, indem sie zu TestBG hinzugefügt wird
-	 * @param x Größe in X-Richtung
-	 * @param y Größe in Y-Richtung
-	 * @param z Größe in Z-Richtung
-	 * @param transform Transformation, die auf die Box angewendet werden soll
-	 * @param angle Winkel, um den die Box gedreht werden soll
+	 * 
+	 * @param x			Größe in X-Richtung
+	 * @param y			Größe in Y-Richtung
+	 * @param z			Größe in Z-Richtung
+	 * @param transform	Transformation, die auf die Box angewendet werden soll
+	 * @param angle		Winkel, um den die Box gedreht werden soll
 	 */
 	public void showDebugBox(final double x, final double y, final double z, Transform3D transform, double angle) {
 		final Box box = new Box((float) x, (float) y, (float) z, null);
@@ -632,9 +621,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		testBG.addChild(bg);
 	}
 
-	/**
-	 * Startet den Bot (bzw. dessen Thread).
-	 */
+	/** Startet den Bot (bzw. dessen Thread) */
 	public final void start() {
 		thrd = new Thread(this, "ctSim-"+toString());
 		addDisposeListener(new Runnable() {
@@ -652,13 +639,11 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		lg.fine("Thread " + thrd.getName() + " gestartet");
 	}
 
-	/**
-	 *  Stoppt den Bot (bzw. dessen Thread).
-	 */
+	/** Stoppt den Bot (bzw. dessen Thread) */
 	@Override
 	public void dispose() {
-		super.dispose(); // Unsere DisposeListener
-		bot.dispose(); // und die vom Wrappee
+		super.dispose();	// Unsere DisposeListener
+		bot.dispose();	// und die vom Wrappee
 	}
 
 	/**
@@ -683,7 +668,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	}
 
 	/**
-	 * @param posInWorldCoord Die Position, an die der Bot gesetzt werden soll
+	 * @param posInWorldCoord	Die Position, an die der Bot gesetzt werden soll
 	 */
 	public final synchronized void setPosition(Point3d posInWorldCoord) {
 		// Optimierung (Transform-Kram ist teuer)
@@ -705,7 +690,8 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Setzt Heading
-	 * @param headingInRad Heading als RAD
+	 * 
+	 * @param headingInRad	Heading als RAD
 	 */
 	public final synchronized void setHeading(double headingInRad) {
 		setHeading(vectorFromAngle(headingInRad));
@@ -713,7 +699,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * @param headingInRad	Heading als RAD
-	 * @return	Heading als Vektor
+	 * @return Heading als Vektor
 	 */
 	public static Vector3d vectorFromAngle(double headingInRad) {
 		headingInRad = Misc.normalizeAngleRad(headingInRad);
@@ -722,6 +708,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Setzt Heading
+	 * 
 	 * @param headingInWorldCoord	Heading in Welt-Koordinaten
 	 */	
 	public final synchronized void setHeading(Vector3d headingInWorldCoord) {
@@ -732,8 +719,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 		/*
 		 * Sinn der Methode: Transform3D aktualisieren, das von Bot- nach
-		 * Weltkoordinaten transformiert. (Dieses steckt in unserer
-		 * TransformGroup.)
+		 * Weltkoordinaten transformiert. (Dieses steckt in unserer TransformGroup.)
 		 */
 		this.headingInWorldCoord = headingInWorldCoord;
 
@@ -754,22 +740,23 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	 *          0
 	 *          .
 	 *          .
-	 * +&pi;/2 . . . . . &minus;&pi;/2
+	 * +π/2 . . . . . -π/2
 	 *          .
 	 *          .
-	 *         +&pi;
+	 *         +π
 	 * </pre>
 	 *
 	 * </p>
 	 * <p>
 	 * Liefert den Winkel zwischen positiver y-Achse der Welt und
 	 * übergebenem Vektor. Ergebnis ist im Bogenmaß und liegt im
-	 * Intervall ]&minus;&pi;; +&pi;]. Gemessen im Gegenuhrzeigersinn
+	 * Intervall ]-π; +π]. Gemessen im Gegenuhrzeigersinn
 	 * ("mathematisch positiver Drehsinn"), d.h. positive Winkel liegen links,
 	 * wenn man in Richtung der y-Achse guckt. Ein Vektor, der exakt in Richtung
-	 * der negativen y-Achse zeigt, produziert +&pi; als Ergebnis.
+	 * der negativen y-Achse zeigt, produziert +π als Ergebnis.
 	 * </p>
-	 * @param v Vektor
+	 * 
+	 * @param v	Vektor
 	 * @return Winkel
 	 */
 	private static double radiansToYAxis(Vector3d v) {
@@ -781,7 +768,6 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	}
 
 	/**
-	 * 
 	 * @param state
 	 * @param setOrClear
 	 */
@@ -794,8 +780,9 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	}
 
 	/**
-* Fügt einen Status hinzu
-	 * @param state Status
+	 * Fügt einen Status hinzu
+	 * 
+	 * @param state	Status
 	 */
 	public void set(State state) {
 		if (obstState.add(state)) {
@@ -806,7 +793,8 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Entfernt Status
-	 * @param state Status
+	 * 
+	 * @param state	Status
 	 */
 	public void clear(State state) {
 		if (obstState.remove(state)) {
@@ -831,6 +819,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	}
 
 	// Gemäß dbfeld-ctsim-log-state.txt
+	
 	/**
 	 * @return log-state
 	 */
@@ -844,22 +833,21 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	
 	/**
 	 * Schreibt eine Info-Nachricht in die Konsole
-	 * @param s Nachricht
+	 * 
+	 * @param s	Nachricht
 	 */
 	public void printInfoMsg(String s) {
 		lg.info(toString() + " " + s);
 	}
 
 	/**
-	 * Überschreibt die run()-Methode aus der Klasse Thread und arbeitet in
-	 * einer Endlosschleife zwei Schritte ab:
+	 * Überschreibt die run()-Methode aus der Klasse Thread
+	 * und arbeitet in einer Endlosschleife zwei Schritte ab:
 	 * <ul>
-	 * <li>auf unserem SimulatedBot
-	 * {@link SimulatedBot#doSimStep() doSimStep()} aufrufen</li>
+	 * <li>auf unserem SimulatedBot {@link SimulatedBot#doSimStep() doSimStep()} aufrufen</li>
 	 * <li>{@link #updateView()} aufrufen</li>
 	 * </ul>
-	 * Die Schleife läuft so lang, bis sie von der Methode
-	 * {@link #dispose()} beendet wird.
+	 * Die Schleife läuft so lang, bis sie von der Methode {@link #dispose()} beendet wird.
 	 */
 	public final void run() {
 		Thread thisThread = Thread.currentThread();
@@ -905,12 +893,10 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	@Override
 	public void updateView() throws InterruptedException {
 		super.updateView();	// Positionsanzeige updaten
-		bot.updateView(); // Anzeige der Bot-Komponenten updaten
+		bot.updateView();	// Anzeige der Bot-Komponenten updaten
 	}
 
-	/**
-	 * Aktualisiert die Bot-Ansicht
-	 */
+	/** Aktualisiert die Bot-Ansicht */
 	private void updateAppearance() {
 		String key;
 		if (isObstStateNormal()) {
@@ -918,7 +904,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		} else {
 			// appearanceKey des ersten gesetzten Elements
 			// Im Fall, dass mehr als ein ObstState gesetzt ist (z.B. COLLIDED
-			// und zugleich HALTED), werden alle ignoriert ausser dem ersten
+			// und zugleich HALTED), werden alle ignoriert außer dem Ersten
 			key = obstState.iterator().next().appearanceKeyInXml;
 		}
 
@@ -930,11 +916,11 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	}
 
 	/**
-	 * Diese Methode wird von außen aufgerufen und erledigt die
-	 * Aktualisierung der Simulation: Bot-Position weitersetzen je nach dem,
-	 * wie schnell die Motoren gerade drehen usw.
+	 * Diese Methode wird von außen aufgerufen und erledigt die Aktualisierung der
+	 * Simulation: Bot-Position weitersetzen je nach dem, wie schnell die Motoren
+	 * gerade drehen usw.
 	 *
-	 * @param simTimeInMs Aktuelle Simulation in Millisekunden
+	 * @param simTimeInMs	Aktuelle Simulation in Millisekunden
 	 */
 	public void updateSimulation(long simTimeInMs) {
 		if (is(HALTED)) { // Fix für Bug 44
@@ -957,7 +943,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 	 * Liefert die Sim-Zeit, die verstrichen ist seit dem vorigen Aufruf von
 	 * updateSimulation().
 	 *
-	 * @return Delta-T in Millisekunden
+	 * @return Delta-T	in Millisekunden
 	 */
 	public long getDeltaTInMs() {
 		return deltaT;
@@ -965,6 +951,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Liefert die letzte als sicher erachtete Position des Bots zurück
+	 * 
 	 * @return Returns the lastSavePos.
 	 */
 	public Point3d getLastSafePos() {
@@ -973,8 +960,9 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Rechnet Bot-Koordinaten in Welt-Koordinaten um
-	 * @param inBotCoord	Bot-Koordis als Point
-	 * @return				Welt-Koordis
+	 * 
+	 * @param inBotCoord	Bot-Koordinaten als Point
+	 * @return Welt-Koordinaten
 	 */
 	public Point3d worldCoordFromBotCoord(Point3d inBotCoord) {
 		Point3d rv = (Point3d)inBotCoord.clone();
@@ -986,8 +974,8 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Rechnet Bot-Koordinaten in Welt-Koordinaten um
-	 * @param inBotCoord	Bot-Koordis als Vektor
-	 * @return				Welt-Koordis
+	 * @param inBotCoord	Bot-Koordinaten als Vektor
+	 * @return Welt-Koordinaten
 	 */
 	public Vector3d worldCoordFromBotCoord(Vector3d inBotCoord) {
 		Vector3d rv = (Vector3d) inBotCoord.clone();
@@ -1007,6 +995,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 
 	/**
 	 * Setzt einen Handler für geändertes Aussehen
+	 * 
 	 * @param calledWhenObstStateChanged
 	 */
 	public void addAppearanceListener(Runnable1<Color> calledWhenObstStateChanged) {
@@ -1048,9 +1037,7 @@ public class ThreeDBot extends BasicBot implements Runnable {
 		return bot;
 	}
 
-	/**
-	 * sendet Fernbedienungs-Startcode an den einen (TCP-)c't-Bot
-	 */
+	/** sendet Fernbedienungs-Startcode an den einen (TCP-)c't-Bot */
 	public void sendRcStartCode() {
 		if (bot instanceof CtBotSimTcp) {
 			((CtBotSimTcp)bot).sendRcStartCode();

--- a/ctSim/model/TurningPoint.java
+++ b/ctSim/model/TurningPoint.java
@@ -23,54 +23,46 @@ import java.util.Vector;
 import javax.vecmath.Vector2d;
 
 /**
- * Diese Klasse beschreibt die Position eines Knicks im Pfad des Roboters, wenn
- * er an einem Hindernis abbiegt. Ausserdem enthält sie Methoden um die
- * Kuerzeste Verbindung in einem ungerichteten Graphen zu finden
+ * Diese Klasse beschreibt die Position eines Knicks im Pfad des Roboters,
+ * wenn er an einem Hindernis abbiegt. Ausserdem enthält sie Methoden um die
+ * kürzeste Verbindung in einem ungerichteten Graphen zu finden
  *
  * @author phophermi (mpraehofer@web.de)
- *
  */
 public class TurningPoint {
 	/**
 	 * <p>
 	 * Der Abstand, wie weit der Mittelpunkt des Bots von den
-	 * Wänden/Löchern/andern Hindernissen hält, in
-	 * Grid-Einheiten.
+	 * Wänden/Löchern/andern Hindernissen hält, in Grid-Einheiten.
 	 * </p>
 	 * <p>
-	 * 0.25 ist <strong>bei momentaner Block-Größe</strong> ein
-	 * Bot-Radius. ("Block-Größe": siehe blockSizeInM in
-	 * der Klasse Parcours.) 0.25 bedeutet also, dieser der
-	 * Wegfindungs-Algorithmus erlaubt dem Bot, bis zur Kollision an Wände
+	 * 0.25 ist <strong>bei momentaner Block-Größe</strong> ein Bot-Radius.
+	 * ("Block-Größe": siehe blockSizeInM in der Klasse Parcours.) 0.25 bedeutet also,
+	 * dass dieser Wegfindungs-Algorithmus dem Bot erlaubt , bis zur Kollision an Wände
 	 * heranzukommen.
 	 * </p>
 	 * <ol>
 	 * <h3>Probleme:</h3>
-	 * <li>Wenn dieser Wert zu groß ist (z.B. 0.25), und man den Weg bis
-	 * zum Ziel bestimmt von der Position eines Bots aus, kann folgendes
-	 * passieren: Bots, die mit ihrer Vorderseite ein bisschen über einem
-	 * Loch stehen, sind nach Meinung dieses Algorithmus in ungültiger
-	 * Position. Das heißt, dass
-	 * {@link #getShortestPathTo(TurningPoint, int[][])} zurückliefert, es
-	 * gäbe keinen gültigen Weg von der Botposition zum Ziel, obwohl
-	 * laut {@link ThreeDBot} der Bot noch lang nicht in ein Loch gefallen
-	 * ist. </li>
+	 * <li>Wenn dieser Wert zu groß ist (z.B. 0.25), und man den Weg bis zum Ziel bestimmt
+	 * von der Position eines Bots aus, kann folgendes passieren:
+	 * Bots, die mit ihrer Vorderseite ein bisschen über einem Loch stehen, sind nach Meinung
+	 * dieses Algorithmus in ungültiger Position. Das heißt, dass
+	 * {@link #getShortestPathTo(TurningPoint, int[][])} zurückliefert, es gäbe keinen gültigen
+	 * Weg von der Botposition zum Ziel, obwohl laut {@link ThreeDBot} der Bot noch lange nicht
+	 * in ein Loch gefallen ist. </li>
 	 * <li> Es ist nicht empfehlenswert, diesen Wert auf 0 zu setzen.
-	 * Angenommen, solche Stellen kommen auf der Karte (XML) vor:<br /> #<br />
-	 * #===<br /> #<br/> Ein Weg zum Ziel wird dann auch gefunden in der
-	 * zweiten Zeile zwischen den Blöcken "#" und "=",
-	 * wo der Bot natürlich nicht durchkommt. Dieser Wegfindungsalgorithmus
-	 * ist für den Wert 0 also praktisch nutzlos, da er auch Wege durch
-	 * Wände u.dgl. sucht. </li>
+	 * Angenommen, solche Stellen kommen auf der Karte (XML) vor: <br /> #<br />
+	 * #===<br /> #<br/>
+	 * Ein Weg zum Ziel wird dann auch gefunden in der zweiten Zeile zwischen den Blöcken "#" und "=",
+	 * wo der Bot natürlich nicht durchkommt. Dieser Wegfindungsalgorithmus ist für den Wert 0
+	 * also praktisch nutzlos, da er auch Wege durch Wände u.dgl. sucht.</li>
 	 * </ol>
 	 * 
-	 * 
-	 * Mist: Dieser Algorithmus hat ganz eigene Vorstellungen davon, was 
-	 * "Bot ist in ein Loch gefallen" heisst (nämlich Bot-Zentrum ist näher als 
-	 * distFromCorner an einer Ecke). Es wäre besser, wenn das Model und diese 
-	 * Klasse einen Bot unter den gleichen Umständen als "im Loch" betrachten, 
-	 * nicht unter subtil unterschiedlichen Umständen.
-	 * Variable distFromCorner ist wirklich problematisch und sollte anders geloest werden -- siehe ihre Doku
+	 * Mist: Dieser Algorithmus hat ganz eigene Vorstellungen davon, was "Bot ist in ein Loch gefallen"
+	 * heißt (nämlich Bot-Zentrum ist näher als distFromCorner an einer Ecke). Es wäre besser,
+	 * wenn das Model und diese Klasse einen Bot unter den gleichen Umständen als "im Loch" betrachten, 
+	 * und nicht unter subtil unterschiedlichen Umständen. Variable distFromCorner ist wirklich
+	 * problematisch und sollte anders gelöst werden -- siehe zugehörige Doku
 	 */
 	public static final double distFromCorner = 0.05;
 
@@ -83,7 +75,7 @@ public class TurningPoint {
 	/**
 	 * z-Koordinate der Linie: 0 entspricht Bodenhöhe, dann wird die Linie
 	 * allerdings von Start- und Zielfeld überdeckt. Nicht getestet wurde ob
-	 * der bot stolpert, wenn height>0
+	 * der bot stolpert, wenn height > 0
 	 */
 	public static final float height = 0.0f;
 
@@ -94,8 +86,8 @@ public class TurningPoint {
 	Vector2d pos;
 
 	/**
-	 * @param x X-Koordinate
-	 * @param y Y-Koordinate
+	 * @param x	X-Koordinate
+	 * @param y	Y-Koordinate
 	 */
 	TurningPoint(double x, double y) {
 		pos = new Vector2d();
@@ -104,7 +96,7 @@ public class TurningPoint {
 	}
 
 	/**
-	 * @param p x/Y als Vektor
+	 * @param p	x/Y als Vektor
 	 */
 	TurningPoint(Vector2d p) {
 		pos = new Vector2d(p);
@@ -114,8 +106,8 @@ public class TurningPoint {
 	 * Testet ob this mit p2 in der parcoursMapSimple auf direktem Wege vom Bot
 	 * erreicht werden können
 	 *
-	 * @param p2 Zu testender Punkt
-	 * @param parcoursMapSimple ParcoursMap
+	 * @param p2				Zu testender Punkt
+	 * @param parcoursMapSimple	ParcoursMap
 	 * @return true wenn direkt erreichbar
 	 */
 	boolean isDirectlyConnectedTo(TurningPoint p2, int[][] parcoursMapSimple) {
@@ -185,7 +177,7 @@ public class TurningPoint {
 	 *
 	 * @param path
 	 * @param M
-	 * @return länge von path bezüglich M
+	 * @return Länge von path bezüglich M
 	 */
 	static double getLengthOfPath(Vector<Integer> path, double[][] M) {
 		double l = 0;
@@ -203,9 +195,9 @@ public class TurningPoint {
 	}
 
 	/**
-	 * gibt die Länge des durch path gegebenen Streckenzugs zurück
+	 * Gibt die Länge des durch path gegebenen Streckenzugs zurück
 	 *
-	 * @param path der Streckenzug
+	 * @param path	der Streckenzug
 	 * @return länge von path bezüglich M
 	 */
 	static double getLengthOfPath(Vector<TurningPoint> path) {
@@ -224,16 +216,15 @@ public class TurningPoint {
 	}
 
 	/**
-	 * die kuerzeste Verbindung von this zu p2 wird rekursiv bestimmt
+	 * die kürzeste Verbindung von this zu p2 wird rekursiv bestimmt
 	 *
-	 * @param s	?
-	 * @param f	?
+	 * @param s			?
+	 * @param f			?
 	 * @param initPath	der bisher untersuchte Weg
 	 * @param cutoff	ist der untersuchte Weg länger wird abgebrochen
-	 * @param M Inzidenzmatrix
-	 * @param N	?
-	 * @return die kuerzeste Verbindung von this zu p2 unter Vermeidung von
-	 *         initialPath
+	 * @param M			Inzidenzmatrix
+	 * @param N			?
+	 * @return die kürzeste Verbindung von this zu p2 unter Vermeidung von initialPath
 	 */
 	Vector<Integer> getShortestPath(int s, int f, Vector<Integer> initPath,
 			double cutoff, double[][] M, int[][] N) {
@@ -282,7 +273,7 @@ public class TurningPoint {
 	}
 
 	/**
-	 * gibt einen Polygonzug der mit Breite und einer Spitze versehen Linie von
+	 * Gibt einen Polygonzug der mit Breite und einer Spitze versehen Linie von
 	 * this zu p2 zurück, zur Weiterverwendung in createLine()
 	 *
 	 * @param p2
@@ -333,10 +324,10 @@ public class TurningPoint {
 	}
 
 	/**
-	 * Findet alle möglichen Eckpunkte der kuerzesten Verbindung
+	 * Findet alle möglichen Eckpunkte der kürzesten Verbindung
 	 *
 	 * @param parcoursMapSimple
-	 * @return eine Liste möglicher Eckpunkte für die kuerzesten Verbindung
+	 * @return eine Liste möglicher Eckpunkte für die kürzeste Verbindung
 	 */
 	Vector<TurningPoint> findTurningPoints(int[][] parcoursMapSimple) {
 		Vector<TurningPoint> turningPoints = new Vector<TurningPoint>();
@@ -383,12 +374,12 @@ public class TurningPoint {
 	}
 
 	/**
-	 * Kreiert die Incidenzmatrix der Punkteliste bezüglich parcoursMapSimple
+	 * Erzeugt die Incidenzmatrix der Punkteliste bezüglich parcoursMapSimple
 	 *
 	 * @param turningPoints
 	 * @param parcoursMapSimple
-	 * @return double[i][j] ist der Abstand von Punkt i zu j, falls direkt
-	 *         verbunden, ansonsten 10e30(unendlich)
+	 * @return double[i][j] ist der Abstand von Punkt i zu j, falls direkt verbunden,
+	 * 			ansonsten 10e30 (defacto unendlich)
 	 */
 	double[][] createIncidenceMatrix(Vector<TurningPoint> turningPoints,
 			int[][] parcoursMapSimple) {
@@ -450,12 +441,13 @@ public class TurningPoint {
 	 * <code>this</code> nach <code>finish</code> beschreiben, den der Bot
 	 * im Labyrinth <code>parcoursMapSimple</code> durchfahren kann.
 	 *
-	 * @param finish Der Punkt, zu dem der kürzeste Weg bestimmt werden
-	 * soll; typischerweise das Zielfeld des Labyrinths.
-	 * @param parcoursMapSimple Vereinfachte Karte des Parcours: 0 = befahrbar,
-	 * 1 = Hindernis
-	 * @return Eckpunkte der kürzesten Verbindung von <code>this</code> zu
-	 * finish. Die Liste kann leer sein.
+	 * @param finish
+	 * 				Der Punkt, zu dem der kürzeste Weg bestimmt werden soll;
+	 * 				typischerweise das Zielfeld des Labyrinths.
+	 * @param parcoursMapSimple
+	 * 				Vereinfachte Karte des Parcours: 0 = befahrbar, 1 = Hindernis
+	 * @return Eckpunkte der kürzesten Verbindung von <code>this</code> zu finish.
+	 * 			Die Liste kann leer sein.
 	 */
 	Vector<TurningPoint> getShortestPathTo(TurningPoint finish,
 			int[][] parcoursMapSimple) {
@@ -468,7 +460,7 @@ public class TurningPoint {
 				parcoursMapSimple);
 		// Erstellen der Tabelle der jeweils direkt erreichbaren Nachbarn
 		int[][] neighbors = this.getDirectNeighbors(incidenceMatrix);
-		// finde die kuerzeste Verbindung
+		// finde die kürzeste Verbindung
 		Vector<Integer> shortestPath = turningPoints.get(0).getShortestPath(0,
 				1, new Vector<Integer>(), 1e30, incidenceMatrix, neighbors);
 		Vector<TurningPoint> shortest = new Vector<TurningPoint>();

--- a/ctSim/model/World.java
+++ b/ctSim/model/World.java
@@ -69,18 +69,16 @@ import ctSim.util.Misc;
 import ctSim.view.gui.StatusBar;
 
 /**
- * <p>Welt-Modell, kümmert sich um die globale Simulation und das
- * Zeitmanagement.</p>
+ * <p>Welt-Modell, kümmert sich um die globale Simulation und das Zeitmanagement.</p>
  *
- * <p>Zum Erzeugen einer Welt die statischen Methoden
- * <code>buildWorldFrom...()</code> verwenden.</p>
+ * <p>Zum Erzeugen einer Welt die statischen Methoden <code>buildWorldFrom...()</code> verwenden.</p>
  *
  * @author Benjamin Benz (bbe@heise.de)
- * @author Peter Koenig (pek@heise.de)
+ * @author Peter König (pek@heise.de)
  * @author Lasse Schwarten (lasse@schwarten.org)
  * @author Christoph Grimmer (c.grimmer@futurio.de)
  * @author Werner Pirkl (morpheus.the.real@gmx.de)
- * @author Hendrik Krauß &lt;<a href="mailto:hkr@heise.de">hkr@heise.de</a>>
+ * @author Hendrik Krauß (hkr@heise.de)
  */
 public class World {
 	/** Logger */
@@ -120,17 +118,16 @@ public class World {
 	/** @see #setSimStepIntervalInMs(int) */
 	private int simStepIntervalInMs = 0;
 
-	/** <p>Pro Simulationsschritt rückt die Simulationszeit-Uhr um diesen
-	 * Wert vor. Einheit Millisekunden.</p>
+	/** <p>Pro Simulationsschritt rückt die Simulationszeit-Uhr um diesen Wert vor.
+	 *  Einheit Millisekunden.</p>
 	 *
-	 * $$ Dokumentieren: Bot kriegt Zeit in diesen Schritten mitgeteilt; setzt indirekt max. Aufloesung
+	 * $$ Dokumentieren: Bot kriegt Zeit in diesen Schritten mitgeteilt; setzt indirekt max. Auflösung
 	 */
 	private static final int SIM_TIME_PER_STEP =
 		Integer.parseInt(Config.getValue("simTimePerStep"));
 
-	/** <p>Gegenwärtige Simulationszeit. Sie ist gleich <em>Zahl der
-	 * bisher ausgeführten Simulationsschritte &times;
-	 * <code>SIM_TIME_PER_STEP</code></em>. Einheit Millisekunden.</p>
+	/** <p>Gegenwärtige Simulationszeit. Sie ist gleich <em>Zahl der bisher ausgeführten
+	 * Simulationsschritte x <code>SIM_TIME_PER_STEP</code></em>. Einheit Millisekunden.</p>
 	 *
 	 * @see #getSimTimeInMs()
 	 */
@@ -144,9 +141,7 @@ public class World {
 	private final List<ThreeDBot> botsToStart = Misc.newList();
 
 	
-	/**
-	 * Startet die neuen Bots
-	 */
+	/** Startet die neuen Bots */
 	public synchronized void startBots() {
 		for (ThreeDBot b : botsToStart) {
 			b.start();
@@ -157,15 +152,14 @@ public class World {
 
 	/**
 	 * Ermittelt die neue Anzahl an Bots (aktive + neue)
+	 * 
 	 * @return Botanzahl
 	 */
 	public synchronized int getFutureNumOfBots() {
 		return botsRunning.size() + botsToStart.size();
 	}
 
-	/**
-	 * Entfernt alle Bots
-	 */
+	/** Entfernt alle Bots */
 	public synchronized void removeAllBotsNow() {
 		// Listen kopieren: b.dispose() entfernt den Bot aus botsToStart und
 		// botsRunning, ein Iterator wuerde also eine ConcurrentModificationExcp
@@ -181,15 +175,11 @@ public class World {
 	///////////////////////////////////////////////////////////////////////////
 
 	/**
-	 * <p>
-	 * Liefert den Zeitraffer-/Zeitlupen-Faktor: Wieviel Realzeit
-	 * (Armbanduhrenzeit) vergeht zwischen dem Beginn eines Simulatorschritts
-	 * und dem Beginn des nächsten Simulatorschritts? – Einheit
-	 * Millisekunden.
-	 * </p>
-	 * <p>
-	 * Näheres siehe {@link #setSimStepIntervalInMs(int)}.
-	 * </p>
+	 * <p> Liefert den Zeitraffer-/Zeitlupen-Faktor: Wieviel Realzeit (Armbanduhrenzeit) vergeht
+	 * zwischen dem Beginn eines Simulatorschritts und dem Beginn des nächsten Simulatorschritts?
+	 * Die Einheit ist Millisekunden.</p>
+	 * <p>Näheres siehe {@link #setSimStepIntervalInMs(int)}.</p>
+	 * 
 	 * @return Zeitintervall
 	 */
 	public int getSimStepIntervalInMs() {
@@ -197,17 +187,16 @@ public class World {
 	}
 
 	/** <p>Setzen des Zeitraffer-/Zeitlupen-Faktors:
-	 * Stellt ein, wieviel Realzeit (Armbanduhrenzeit) zwischen zwei
-	 * Schritten der Simulation vergeht. Einheit Millisekunden.</p>
+	 * Stellt ein, wieviel Realzeit (Armbanduhrenzeit) zwischen zwei Schritten der Simulation
+	 * vergeht. Die Einheit ist Millisekunden.</p>
 	 *
-	 * <p>Vorgänge in der Simulation werden von diesem Wert nicht
-	 * beeinflusst, da unabhängig von ihm jeder Simulationsschritt
-	 * ausgeführt wird. Der Wert beeinflusst nur, wie lange
-	 * zwischen den Schritten (in Realzeit) gewartet wird.</p>
+	 * <p>Vorgänge in der Simulation werden von diesem Wert nicht beeinflusst, da jeder Simulationsschritt
+	 * unabhängig von ihm ausgeführt wird. Der Wert beeinflusst nur, wie lange zwischen den Schritten
+	 * (in Realzeit) gewartet wird.</p>
 	 *
-	 * @param timeInterval Zeitspanne [ms], wieviel Zeit zwischen dem
-	 * Beginn eines Simulatorschritts und dem Beginn des folgenden
-	 * Simulatorschritts liegen soll.
+	 * @param timeInterval
+	 * 				Zeitspanne [ms], wieviel Zeit zwischen dem Beginn eines Simulatorschritts
+	 * 				und dem Beginn des folgenden Simulatorschritts liegen soll.
 	 */
     public void setSimStepIntervalInMs(int timeInterval) {
     	simStepIntervalInMs = Math.min(timeInterval, StatusBar.MAX_TICK_RATE);
@@ -215,21 +204,19 @@ public class World {
 
 	/** Liefert die aktuelle Simulationszeit in Millisekunden.
 	 *
-	 * @return Die momentane Simulationszeit [ms]. Sie ist gleich der Zahl
-	 * der bisher ausgeführten Simulationsschritte mal einem
-	 * konstanten Faktor. Daher ist sie unabhängig von der Realzeit
-	 * (Armbanduhrenzeit): eine Sim-Sekunde ist im allgemeinen
-	 * nicht gleich lang wie eine Armbanduhr-Sekunde, und zudem wird
-	 * die Simzeit-Uhr beispielsweise angehalten, wenn in der GUI der
-	 * Pause-Knopf gedrückt wird. Simzeit und Realzeit unterscheiden
-	 * sich also sowohl um Summanden als auch um einen Faktor.
+	 * @return Die momentane Simulationszeit [ms].
+	 * 			Sie ist gleich der Zahl der bisher ausgeführten Simulationsschritte mal einem
+	 * 			konstanten Faktor. Daher ist sie unabhängig von der Realzeit (Armbanduhrenzeit):
+	 * 			eine Sim-Sekunde ist im Allgemeinen	nicht gleich lang wie eine Armbanduhr-Sekunde,
+	 * 			und zudem wird die Simzeit-Uhr beispielsweise angehalten, wenn in der GUI der
+	 * 			Pause-Knopf gedrückt wird. Simzeit und Realzeit unterscheiden sich also sowohl
+	 * 			um Summanden als auch um einen Faktor.
 	 */
     public long getSimTimeInMs() {
 		return simTimeInMs;
     }
 
-	/** Setzt die Simulationszeit-Uhr um den Gegenwert eines
-	 * Simulationsschrittes weiter.
+	/** Setzt die Simulationszeit-Uhr um den Gegenwert eines Simulationsschrittes weiter.
 	 *
 	 * @see #SIM_TIME_PER_STEP
 	 * @see #getSimTimeInMs()
@@ -243,8 +230,8 @@ public class World {
 
 	/**
 	 * Lädt einen Parcours aus einer Datei und baut damit eine Welt.
-	 * @param sourceFile Die zu öffnende Datei. Sie
-	 * hat in dem für Parcours vorgesehenen Schema zu sein.
+	 * 
+	 * @param sourceFile	Die zu öffnende Datei. Sie hat in dem für Parcours vorgesehenen Schema zu sein.
 	 * @return Die neue Welt
 	 * @throws SAXException 
 	 * @throws IOException 
@@ -261,8 +248,7 @@ public class World {
 		in.close();
 		return new World(new InputSource(sourceFile.toURI().toString()), 
 			/* Der EntityResolver hat den Sinn, dem Parser zu sagen,
-			 * er soll die parcours.dtd bitte im Verzeichnis "parcours"
-			 * suchen. */
+			 * er soll die parcours.dtd im Verzeichnis "parcours" suchen. */
 			new EntityResolver() {
 				public InputSource resolveEntity(String publicId, String systemId)
 				throws SAXException, IOException {
@@ -277,10 +263,11 @@ public class World {
 	}
 
 	/** Lädt einen Parcours aus einem String und baut damit eine Welt.
-	 * @param parcoursAsXml Der String, der die XML-Darstellung des Parcours
-	 * enthält. Das XML muss in dem für Parcours vorgesehenen Schema
-	 * sein. Die in Zeile&nbsp;2 des XML angegebene DTD-Datei wird von dieser
-	 * Methode im Unterverzeichnis "parcours" gesucht. 
+	 * 
+	 * @param parcoursAsXml
+	 * 				Der String, der die XML-Darstellung des Parcours enthält. Das XML muss in dem
+	 * 				für Parcours vorgesehenen Schema sein. Die in Zeile 2 des XML angegebene
+	 * 				DTD-Datei wird von dieser Methode im Unterverzeichnis "parcours" gesucht. 
 	 * @return Die neue Welt
 	 * @throws SAXException 
 	 * @throws IOException
@@ -292,8 +279,7 @@ public class World {
 		return new World(
 			new InputSource(new StringReader(parcoursAsXml)),
 			/* Der EntityResolver hat den Sinn, dem Parser zu sagen,
-			 * er soll die parcours.dtd bitte im Verzeichnis "parcours"
-			 * suchen. */
+			 * er soll die parcours.dtd im Verzeichnis "parcours" suchen. */
 			new EntityResolver() {
 				public InputSource resolveEntity(String publicId, String systemId)
 				throws SAXException, IOException {
@@ -309,28 +295,26 @@ public class World {
 	///////////////////////////////////////////////////////////////////////////
 
 	/**
-	 * <p>
-	 * Liest einen Parcours aus einer XML-Quelle und baut damit eine Welt.
-	 * </p>
-	 * <p>
-	 * Der Konstruktor ist privat, da ihn niemand von außen verwendet hat.
-	 * Es stehen die statischen Methoden <code>buildWorldFromFile</code> und
-	 * <code>buildWorldFromXmlString</code> aus dieser Klasse zu
-	 * Verfügung, um Welten zu erzeugen.
-	 * </p>
+	 * <p>Liest einen Parcours aus einer XML-Quelle und baut damit eine Welt.</p>
+	 * 
+	 * <p>Der Konstruktor ist privat, da ihn niemand von außen verwendet hat.
+	 * Es stehen die statischen Methoden <code>buildWorldFromFile</code>
+	 * und <code>buildWorldFromXmlString</code> aus dieser Klasse zu Verfügung,
+	 * um Welten zu erzeugen.</p>
 	 *
-	 * @param source Die Xerces-Eingabequelle, aus der der die XML-Darstellung
-	 * des Parcours kommt. Das Parsen der Quelle liefert einen Parcours, auf
-	 * dessen Grundlage eine Instanz der Welt konstruiert wird.
-	 * <code>source</code> kann auf die Parcours-Datei zeigen oder (via einen
-	 * java.io.StringReader) auf das in einem String stehende XML. Potentiell
-	 * auch auf anderes.
-	 * @param resolver Der Xerces-EntityResolver, der beim Parsen des XML
-	 * verwendet werden soll. Details siehe
-	 * {@link ParcoursLoader#loadParcours(InputSource, EntityResolver)}.
+	 * @param source
+	 * 				Die Xerces-Eingabequelle, aus der der die XML-Darstellung des Parcours kommt.
+	 * 				Das Parsen der Quelle liefert einen Parcours, auf dessen Grundlage eine Instanz
+	 * 				der Welt konstruiert wird. <code>source</code> kann auf die Parcours-Datei zeigen
+	 * 				oder (via einen java.io.StringReader) auf das in einem String stehende XML. Potentiell
+	 * 				auch auf anderes.
+	 * @param resolver
+	 * 				Der Xerces-EntityResolver, der beim Parsen des XML verwendet werden soll.
+	 * 				Details siehe {@link ParcoursLoader#loadParcours(InputSource, EntityResolver)}.
 	 * @throws SAXException
 	 * @throws IOException
-	 * @throws ParserConfigurationException 
+	 * @throws ParserConfigurationException
+	 *  
 	 * @see ParcoursLoader#loadParcours(InputSource, EntityResolver)
 	 */
 	private World(InputSource source, EntityResolver resolver) throws SAXException, IOException, ParserConfigurationException {
@@ -343,7 +327,8 @@ public class World {
 	}
 
 	/**
-	 * Breite in Bloecken
+	 * Breite in Blöcken
+	 * 
 	 * @return Breite
 	 */
 	public int getWidthInGridBlocks() {
@@ -351,7 +336,8 @@ public class World {
 	}
 
 	/**
-	 * Höhe in Bloecken
+	 * Höhe in Blöcken
+	 * 
 	 * @return Höhe
 	 */
 	public int getHeightInGridBlocks() {
@@ -374,14 +360,14 @@ public class World {
 
 	/**
 	 * Erzeugt einen Szenegraphen mit Boden und Grenzen der Roboterwelt
+	 * 
 	 * @param parc Der Parcours
 	 */
 	private void setParcours(Parcours parc) {
 		parcours = parc;
-		// Hindernisse werden an die richtige Position geschoben
-
+		// Hindernisse werden an die richtige Position geschoben:
 		// Zuerst werden sie gemeinsam so verschoben, dass ihre Unterkante genau
-		// buendig mit der Unterkante des Bodens ist:
+		// bündig mit der Unterkante des Bodens ist:
 		Transform3D translate = new Transform3D();
 		translate.set(new Vector3d(0d, 0d, 0.2d - PLAYGROUND_THICKNESS));
 		TransformGroup obstTG = new TransformGroup(translate);
@@ -398,9 +384,7 @@ public class World {
 	    obstBG.setCapability(Node.ALLOW_PICKABLE_READ);
 	}
 
-	/**
-	 * Initialisiert die Welt
-	 */
+	/** Initialisiert die Welt */
 	private void init() {
 		// Die Wurzel des Ganzen:
 		scene = new BranchGroup();
@@ -420,7 +404,7 @@ public class World {
 
 		scene.addChild(worldTG);
 
-		// Lichtquellen einfügen
+		/* Lichtquellen einfügen */
 		// Streulicht (ambient light)
 		BoundingSphere ambientLightBounds = new BoundingSphere(new Point3d(0d, 0d, 0d), 100d);
 		Color3f ambientLightColor = new Color3f(0.33f, 0.33f, 0.33f);
@@ -429,18 +413,18 @@ public class World {
 		ambientLightNode.setEnable(true);
 		worldTG.addChild(ambientLightNode);
 
-		// Die Branchgroup für die Lichtquellen
+		/* Die Branchgroup für die Lichtquellen */
 		lightBG = new BranchGroup();
 		lightBG.setCapability(Node.ALLOW_PICKABLE_WRITE);
 		lightBG.setPickable(true);
 		worldTG.addChild(lightBG);
 		
-		// Die Branchgroup für BPS (IR-Licht)
+		/* Die Branchgroup für BPS (IR-Licht) */
 		bpsBG = new BranchGroup();
 		bpsBG.setPickable(true);
 		worldTG.addChild(this.bpsBG);
 
-		// Die Branchgroup für den Boden
+		/* Die Branchgroup für den Boden */
 		terrainBG = new BranchGroup();
 		terrainBG.setCapability(Node.ALLOW_PICKABLE_WRITE);
 		terrainBG.setPickable(true);
@@ -493,15 +477,17 @@ public class World {
 	}
 
 	/**
-* Fügt eine ViewPlatform hinzu
-	 * @param view Die neue Ansicht
+	 * Fügt eine ViewPlatform hinzu
+	 * 
+	 * @param view	Die neue Ansicht
 	 */
 	public void addViewPlatform(ViewPlatform view) {
 		viewPlatforms.add(view);
 	}
 
 	/**
-* Fügt einen neuen Bot hinzu
+	 * Fügt einen neuen Bot hinzu
+	 * 
 	 * @param bot 		Der neue Bot
 	 * @param barrier 	Barrier für den Bot
 	 * @return Neue ThreeDBot-Instanz
@@ -542,13 +528,12 @@ public class World {
 	/* **********************************************************************
 	 * **********************************************************************
 	 * WORLD_FUNCTIONS
-	 *
 	 * Funktionen für die Sensoren usw. (Abstandsfunktionen u.ä.)
-	 *
 	 */
 
 	/**
 	 * Gibt den Gewinner zurück
+	 * 
 	 * @return ThreeDBot, der gewonnen hat
 	 */
 	public ThreeDBot whoHasWon() {
@@ -561,9 +546,9 @@ public class World {
 	}
 
 	/**
-	 * @param posInWorldCoord Position
-	 * @return {@code true}, falls pos auf einem der Zielfelder des Parcours
-	 * liegt. {@code false} andernfalls.
+	 * @param posInWorldCoord	Position
+	 * @return {@code true}, falls pos auf einem der Zielfelder des Parcours liegt.
+	 * 			{@code false} andernfalls.
 	 */
 	private boolean finishReached(Point3d posInWorldCoord) {
 		return this.parcours.finishReached(new Vector3d(posInWorldCoord));
@@ -571,8 +556,9 @@ public class World {
 
 	/**
 	 * Prüft, ob ein Objekt mit einem Objekt aus der obstacle-BG der Welt kollidiert
-	 * @param body Koerper des Objekts
-	 * @param bounds Grenzen des Objekts
+	 * 
+	 * @param body		Körper des Objekts
+	 * @param bounds	Grenzen des Objekts
 	 * @return PickInfo über die Kollision (null, falls keine)
 	 */
 	public PickInfo getCollision(Group body, Bounds bounds) {
@@ -585,13 +571,13 @@ public class World {
 		PickInfo pickInfo = null;
 
 		synchronized (obstBG) {
-			/* eigenen Koerper verstecken */
+			/* eigenen Körper verstecken */
 			body.setPickable(false);
 			
 			/* Kollisionserkennung von Java3D */
 			pickInfo = obstBG.pickAny(PickInfo.PICK_BOUNDS, PickInfo.NODE, pickBounds);
 			
-			/* eigenen Koerper wieder zurücksetzen */
+			/* eigenen Körper wieder zurücksetzen */
 			body.setPickable(true);
 		}
 		
@@ -606,10 +592,8 @@ public class World {
 	 * Prüft, ob unter dem angegebenen Punkt innerhalb der Bodenfreiheit des
 	 * Bots noch Boden zu finden ist
 	 *
-	 * @param pos
-	 *            Die Position, von der aus nach unten gemessen wird
-	 * @param groundClearance
-	 *            Die als normal anzusehende Bodenfreiheit
+	 * @param pos				Die Position, von der aus nach unten gemessen wird
+	 * @param groundClearance	Die als normal anzusehende Bodenfreiheit
 	 * @return True wenn Bodenkontakt besteht.
 	 */
 	public boolean checkTerrain(Point3d pos, double groundClearance) {
@@ -617,24 +601,18 @@ public class World {
 	}
 
 	/**
-	 * Liefert eine Angabe, wie viel Licht vom Boden absorbiert wird und den
-	 * Linien- bzw. Abgrundsensor nicht mehr erreicht. Je mehr Licht reflektiert
-	 * wird, desto niedriger ist der zurückgegebene Wert. Der Wertebereich
-	 * erstreckt sich von 0 (weiss oder maximale Reflexion) bis 1023 (minimale
-	 * Reflexion, schwarz oder Loch).
+	 * Liefert eine Angabe, wie viel Licht vom Boden absorbiert wird und den Linien-
+	 * bzw. Abgrundsensor nicht mehr erreicht. Je mehr Licht reflektiert wird,
+	 * desto niedriger ist der zurückgegebene Wert. Der Wertebereich erstreckt sich von 0
+	 * (weiss oder maximale Reflexion) bis 1023 (minimale Reflexion, schwarz oder Loch).
 	 *
-	 * Es werden rayCount viele Strahlen gleichmäßig orthogonal zum Heading
-	 * in die Szene geschossen.
+	 * Es werden rayCount viele Strahlen gleichmäßig orthogonal zum Heading in die Szene geschossen.
 	 *
-	 * @param pos
-	 *            Die Position, an der der Sensor angebracht ist
-	 * @param heading
-	 *            Die Blickrichtung
-	 * @param openingAngle
-	 *            Der Oeffnungswinkel des Sensors
-	 * @param rayCount
-	 *            Es werden rayCount viele Strahlen vom Sensor ausgewertet.
-	 * @return Die Menge an Licht, die absorbiert wird, von 1023(100%) bis 0(0%)
+	 * @param pos			Die Position, an der der Sensor angebracht ist
+	 * @param heading		Die Blickrichtung
+	 * @param openingAngle	Der Öffnungswinkel des Sensors
+	 * @param rayCount		Es werden rayCount viele Strahlen vom Sensor ausgewertet.
+	 * @return Die Menge an Licht, die absorbiert wird, von 1023 (100%) bis 0 (0%)
 	 */
 	public short sensGroundReflectionLine(Point3d pos, Vector3d heading, double openingAngle, short rayCount) {
 		// Sensorposition
@@ -652,11 +630,10 @@ public class World {
 		// Transformationsgruppen, für den Sensorsweep
 		Transform3D transformX = new Transform3D();
 
-		// Wenn mehr als ein Strahl ausgesendet werden soll, dann taste
-		// den Sensorbereich parallel zur Achse des Bots ab.
-		// Bei nur einem Strahl schaue in die Mitte.
+		// Wenn mehr als ein Strahl ausgesendet werden soll, dann taste den Sensorbereich
+		// parallel zur Achse des Bots ab. Bei nur einem Strahl schaue in die Mitte.
 		if (rayCount > 2) {
-			// beginne links aussen
+			// beginne links außen
 			AxisAngle4d rotationAxisX = new AxisAngle4d(heading, openingAngle / 2);
 			transformX.set(rotationAxisX);
 			transformX.transform(sensHeading);
@@ -689,39 +666,31 @@ public class World {
 				shape = (Shape3D) pickInfo.getNode();
 				shape.getAppearance().getMaterial().getDiffuseColor(color);
 				// Je nach Farbe wird ein Teil des Lichts zurückgeworfen.
-				// Hierzu wird der Durchschnitt der Rot-, Gruen- und
-				// Blau-Anteile
+				// Hierzu wird der Durchschnitt der Rot-, Grün- und Blau-Anteile
 				// der Farbe bestimmt.
 				absorption += 1 - (color.x + color.y + color.z) / 3;
 			}
 			// Heading anpassen
 			transformX.transform(sensHeading);
-		}// Ende for-Schleife
+		}	// Ende der for-Schleife
 		return (short) (absorption * 1023 / (rayCount));
 	}
 
 	/**
-	 * Liefert eine Angabe, wie viel Licht vom Boden absorbiert wird und den
-	 * Linien- bzw. Abgrundsensor nicht mehr erreicht. Je mehr Licht reflektiert
-	 * wird, desto niedriger ist der zurückgegebene Wert. Der Wertebereich
-	 * erstreckt sich von 0 (weiss oder maximale Reflexion) bis 1023 (minimale
-	 * Reflexion, schwarz oder Loch).
+	 * Liefert eine Angabe, wie viel Licht vom Boden absorbiert wird und den Linien-
+	 * bzw. Abgrundsensor nicht mehr erreicht. Je mehr Licht reflektiert wird,
+	 * desto niedriger ist der zurückgegebene Wert. Der Wertebereich erstreckt sich von 0
+	 * (weiss oder maximale Reflexion) bis 1023 (minimale Reflexion, schwarz oder Loch).
 	 *
-	 * Es werden rayCount viele Strahlen gleichmäßig orthogonal zum Heading in
-	 * die Szene geschossen.
+	 * Es werden rayCount viele Strahlen gleichmäßig orthogonal zum Heading in die Szene geschossen.
 	 *
-	 * Es werden rayCount viele Strahlen gleichmäßig in Form eines "+" in
-	 * die Szene Geschossen.
+	 * Es werden rayCount viele Strahlen gleichmäßig in Form eines "+" in die Szene geschossen.
 	 *
-	 * @param pos
-	 *            Die Position, an der der Sensor angebracht ist
-	 * @param heading
-	 *            Die Blickrichtung
-	 * @param openingAngle
-	 *            Der Oeffnungswinkel des Sensors
-	 * @param rayCount
-	 *            Es werden rayCount viele Strahlen vom Sensor ausgewertet.
-	 * @return Die Menge an Licht, die absorbiert wird, von 1023(100%) bis 0(0%)
+	 * @param pos			Die Position, an der der Sensor angebracht ist
+	 * @param heading		Die Blickrichtung
+	 * @param openingAngle	Der Öffnungswinkel des Sensors
+	 * @param rayCount		Es werden rayCount viele Strahlen vom Sensor ausgewertet.
+	 * @return Die Menge an Licht, die absorbiert wird, von 1023 (100%) bis 0 (0%)
 	 */
 	public short sensGroundReflectionCross(Point3d pos, Vector3d heading, double openingAngle, short rayCount) {
 		double absorption;
@@ -735,20 +704,18 @@ public class World {
 	}
 
 	/**
-	 * <p>
-	 * Liefert die Helligkeit, die auf einen Lichtsensor fällt.
-	 * </p>
-	 * <p>
-	 * Da diese Methode unter Verwendung des PickConeRay implementiert ist, ist
-	 * sie seinen Bugs unterworfen. Ausführliche Dokumentation siehe
-	 * watchObstacle(Point3d, Vector3d, double, Shape3D).
-	 * </p>
+	 * <p>Liefert die Helligkeit, die auf einen Lichtsensor fällt.</p>
+	 * 
+	 * <p> Da diese Methode unter Verwendung des PickConeRay implementiert ist,
+	 * ist sie seinen Bugs unterworfen. Ausführliche Dokumentation siehe
+	 * watchObstacle(Point3d, Vector3d, double, Shape3D).</p>
 	 *
-	 * @param pos Die Position des Lichtsensors
-	 * @param heading Die Blickrichtung des Lichtsensors
-	 * @param lightReach Reichweite des Lichtsensors / m
-	 * @param openingAngle Der Oeffnungswinkel des Blickstrahls / radians
+	 * @param pos			Die Position des Lichtsensors
+	 * @param heading		Die Blickrichtung des Lichtsensors
+	 * @param lightReach	Reichweite des Lichtsensors / m
+	 * @param openingAngle	Der Öffnungswinkel des Blickstrahls / radians
 	 * @return Die Dunkelheit um den Sensor herum, von 1023 (100%) bis 0 (0%)
+	 * 
 	 * @see PickConeRay
 	 */
 	public int sensLight(Point3d pos, Vector3d heading, double lightReach, double openingAngle) {
@@ -777,16 +744,15 @@ public class World {
 	}
 
 	/**
-	 * <p>
-	 * Liefert die Bakencodierung der Bake im Blickfeld mit der kuerzesten 
-	 * Entfernung zum Sensor, oder 1023, falls keine Bake gesehen wird.
-	 * </p>
+	 * <p>Liefert die Bakencodierung der Bake im Blickfeld mit der kürzesten 
+	 * Entfernung zum Sensor, oder 1023, falls keine Bake gesehen wird.</p>
 	 *
-	 * @param pos Die Position des Sensors
-	 * @param end Die Position der maximalen Sensorreichweite
-	 * @param openingAngle Der Oeffnungswinkel des Blickstrahls
-	 * @return Die Bakencodierung, der Bake im Blickfeld mit der kuerzesten 
-	 * Entfernung zum Sensor, oder 1023, falls keine Bake gesehen wird 
+	 * @param pos			Die Position des Sensors
+	 * @param end			Die Position der maximalen Sensorreichweite
+	 * @param openingAngle	Der Öffnungswinkel des Blickstrahls
+	 * @return Die Bakencodierung, der Bake im Blickfeld mit der kürzesten 
+	 * 			Entfernung zum Sensor, oder 1023, falls keine Bake gesehen wird
+	 * 
 	 * @see PickConeSegment
 	 */
 	public int sensBPS(Point3d pos, Point3d end, double openingAngle) {
@@ -821,25 +787,22 @@ public class World {
 	}
 	
 	/**
-	 * <p>
-	 * Liefert die Distanz in Metern zum nächsten Objekt zurück, das
-	 * man sieht, wenn man von der übergebenen Position aus in Richtung des
-	 * übergebenen Endpunktes schaut.
-	 * </p>
+	 * <p>Liefert die Distanz in Metern zum nächsten Objekt zurück, das man sieht,
+	 * wenn man von der übergebenen Position aus in Richtung des übergebenen
+	 * Endpunktes schaut.</p>
 	 *
-	 * @param pos Die Position, von der aus der Seh-Strahl verfolgt wird
-	 * @param end Die Position, wo der Seh-Strahl spätestens enden soll (falls 
-	 * kein Objekt gesehen wird)
-	 * @param openingAngle Der Sehstrahl ist in Wahrheit ein Kegel;
-	 * {@code openingAngle} gibt seinen Öffnungswinkel an (Bogenmaß)
-	 * @param botBody Der Körper des Roboter, der anfragt. Dies ist
-	 * erforderlich, da diese Methode mit einem PickConeSegment implementiert ist,
-	 * d.h. der Körper des Bots muss auf "not pickable" gesetzt
-	 * werden vor Anwendung des Ray und wieder auf "pickable" nach
-	 * Anwendung. Der Grund ist, dass sonst in Grenzfällen der
-	 * Botkörper vom PickConeSegment gefunden wird.
-	 * @return Die Distanz zum nächsten Objekt ("pickable") in
-	 * Metern oder 100 m, falls kein Objekt in Sichtweite
+	 * @param pos	Die Position, von der aus der Seh-Strahl verfolgt wird
+	 * @param end	Die Position, wo der Seh-Strahl spätestens enden soll (falls kein Objekt gesehen wird)
+	 * @param openingAngle
+	 * 				Der Sehstrahl ist in Wahrheit ein Kegel; {@code openingAngle} gibt seinen Öffnungswinkel
+	 * 				an (Bogenmaß).
+	 * @param botBody
+	 * 				Der Körper des Roboter, der anfragt. Dies ist erforderlich, da diese Methode mit einem
+	 * 				PickConeSegment implementiert ist, d.h. der Körper des Bots muss vor der Anwendung des
+	 * 				Ray auf "not pickable" gesetzt werden und nach der Anwendung wieder auf "pickable".
+	 * 				Der Grund ist, dass sonst in Grenzfällen der Botkörper vom PickConeSegment gefunden wird.
+	 * @return Die Distanz zum nächsten Objekt ("pickable") in Metern oder 100 m, falls kein Objekt in Sichtweite
+	 * 
 	 * @see PickConeSegment
 	 */
 	public double watchObstacle(Point3d pos, Point3d end, double openingAngle, Node botBody) {
@@ -872,8 +835,8 @@ public class World {
 	}
 
 	/**
-	 * Damit jedes Obstacle fair behandelt wird, merken wir uns, wer das
-	 * letzte Mal zuerst dran war
+	 * Damit jedes Obstacle fair behandelt wird, merken wir uns,
+	 * wer das letzte Mal zuerst dran war
 	 */
 	private int runningBotsPtr = 0;
 	
@@ -900,13 +863,11 @@ public class World {
 		runningBotsPtr++;
 	}
 
-	/** Schreibt den Parcours der Welt in eine Datei. Es wird dasselbe XML
-	 * in die Datei geschrieben, das beim
-	 * Konstruieren dieser Instanz geparst wurde, um den Parcours der Welt zu
-	 * erhalten.
+	/**
+	 * Schreibt den Parcours der Welt in eine Datei. Es wird dasselbe XML in die Datei geschrieben,
+	 * das beim Konstruieren dieser Instanz geparst wurde, um den Parcours der Welt zu erhalten.
 	 *
-	 * @param targetFile Datei, in die das XML des Parcours ausgegeben wird.
-	 * Sie wird bei Bedarf angelegt.
+	 * @param targetFile	Datei, in die das XML des Parcours ausgegeben wird. Sie wird bei Bedarf angelegt.
 	 */
 	public void writeParcoursToFile(File targetFile) {
 		try {
@@ -921,26 +882,26 @@ public class World {
 	}
 
 	/**
-	 * Ermittelt die kuerzestet Distanz zum Ziel
+	 * Ermittelt die kürzeste Distanz zum Ziel
+	 * 
 	 * @param fromWhere	Anfangsposition
-	 * @return	Entfernung
+	 * @return Entfernung
 	 */
 	public double getShortestDistanceToFinish(Point3d fromWhere) {
 		return getShortestDistanceToFinish(new Vector3d(fromWhere));
 	}
 
 	/**
-	 * Ermittelt die kuerzestet Distanz zum Ziel
+	 * Ermittelt die kürzestet Distanz zum Ziel
+	 * 
 	 * @param fromWhere	Anfangsposition
-	 * @return	Entfernung
+	 * @return Entfernung
 	 */
 	public double getShortestDistanceToFinish(Vector3d fromWhere) {
 		return parcours.getShortestDistanceToFinish(fromWhere);
 	}
 
-	/**
-	 * Beseitige alles, was noch auf die Welt und den Szenegraphen verweist
-	 */
+	/** Beseitige alles, was noch auf die Welt und den Szenegraphen verweist */
 	public void cleanup() {
 		removeAllBotsNow();
 		viewPlatforms.clear();
@@ -954,7 +915,8 @@ public class World {
 
 	/**
 	 * Löscht einen Bot
-	 * @param bot der zu loeschende Bot
+	 * 
+	 * @param bot	der zu löschende Bot
 	 */
 	public void deleteBot(Bot bot) {
 		parcours.setStartFieldUnused(bot);
@@ -962,8 +924,8 @@ public class World {
 	
 	/**
 	 * Setzt alle Bots auf ihre Startpplätze zurück.
-	 * Hier werden nur simulierte Bots (ThreeDBot-Instanzen) berücksichtigt, weil
-	 * sonstige Bots in World nicht bekannt sind! 
+	 * Hier werden nur simulierte Bots (ThreeDBot-Instanzen) berücksichtigt,
+	 * weil sonstige Bots in World nicht bekannt sind! 
 	 */
 	public void resetAllBots() {
 		for (ThreeDBot b : botsRunning) {
@@ -980,10 +942,11 @@ public class World {
 	}
 	
 	/**
-	 * Exportiert die aktuelle Welt in eine Bot-Map-Datei 
-	 * @param bot Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
-	 * @param free Wert, mit dem freie Felder eingetragen werden (z.B. 100)
-	 * @param occupied Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
+	 * Exportiert die aktuelle Welt in eine Bot-Map-Datei
+	 * 
+	 * @param bot		Bot-Nr., dessen Startfeld als Koordinatenursprung der Map benutzt wird
+	 * @param free		Wert, mit dem freie Felder eingetragen werden (z.B. 100)
+	 * @param occupied	Wert, mit dem Hindernisse eingetragen werden (z.B. -100)
 	 * @throws IOException falls Fehler beim Schreiben der Datei
 	 * @throws MapException falls keine Daten in der Map
 	 */
@@ -1007,7 +970,8 @@ public class World {
 	
 	/**
 	 * Rechnet eine Welt-Koordinate in eine globale Position um
-	 * @param worldPos Welt-Position (wie von Java3D verwendet)
+	 * 
+	 * @param worldPos	Welt-Position (wie von Java3D verwendet)
 	 * @return globale Position (wie zur Lokalisierung verwendet) / mm
 	 */
 	public Point2i transformWorldposToGlobalpos(Point3d worldPos) {


### PR DESCRIPTION
Hier nun mal eine Vorschau für ein paar Files mit der Bitte um ein Feedback zu den Header-Kommentaren. Die Files sind manuell editiert.

Testweise ist in den Headern mal einen Zeilenumbruch unter der jeweiligen Überschrift eingefügt, der Text und Parameter trennt. Im gesamten Code ist dan an verschiedenen Stellen mal mit und mal ohne weshalb unklar ist was davon ursprünglich mal vorgesehen war. Alternativ kann man es auch ohne machen, dann wäre es aber sinnvoll die anderen Stellen entsprechend zu ändern.

Aufgefallen ist mir auch das @param @return mal über mehrere Zeilen verteilt ist mit Einrückungen und mal nicht. Hier wäre es auch sinnvoll das mal einheitlich zu machen. Hier ist das nicht berücksichtigt, aber gut erkennbar.

Im Vordergrund sollte hier die Lesbarkeit und ein einheitliches Erscheinungsbild stehen.
Dieser commit als Testballon würde bei Bedarf nochmal modifiziert.